### PR TITLE
corretto errore $cf['cache']['index']

### DIFF
--- a/_mod/_1000.produzione/_src/_inc/_macro/_progetti.produzione.form.php
+++ b/_mod/_1000.produzione/_src/_inc/_macro/_progetti.produzione.form.php
@@ -24,14 +24,14 @@
     
     // tendina clienti
 	$ct['etc']['select']['clienti'] = mysqlCachedIndexedQuery(
-	    $cf['cache']['index'],
+	    $cf['memcache']['index'],
 	    $cf['memcache']['connection'],
         $cf['mysql']['connection'], 
         'SELECT id, __label__ FROM anagrafica_view WHERE se_cliente = 1' );
 
     // tendina anagrafica per referenti e operatori (TODO vedere se filtrare sui referenti del cliente)
     $ct['etc']['select']['anagrafica'] = mysqlCachedIndexedQuery(
-        $cf['cache']['index'],
+        $cf['memcache']['index'],
         $cf['memcache']['connection'],
         $cf['mysql']['connection'], 
         'SELECT id, __label__ FROM anagrafica_view WHERE se_collaboratore = 1 OR se_referente = 1' );
@@ -39,7 +39,7 @@
 
     // tendina indirizzi
 	$ct['etc']['select']['indirizzi'] = mysqlCachedIndexedQuery(
-	    $cf['cache']['index'],
+	    $cf['memcache']['index'],
 	    $cf['memcache']['connection'],
         $cf['mysql']['connection'], 
         'SELECT id, __label__ FROM indirizzi_view' );

--- a/_mod/_1100.attivita/_src/_inc/_macro/_attivita.form.feedback.php
+++ b/_mod/_1100.attivita/_src/_inc/_macro/_attivita.form.feedback.php
@@ -24,14 +24,14 @@
 
     // tendina interesse
 	$ct['etc']['select']['id_interesse'] = mysqlCachedIndexedQuery(
-	    $cf['cache']['index'],
+	    $cf['memcache']['index'],
 	    $cf['memcache']['connection'],
         $cf['mysql']['connection'], 
         'SELECT id, __label__ FROM tipologie_interesse_view' );
 
     // tendina soddisfazione
 	$ct['etc']['select']['id_soddisfazione'] = mysqlCachedIndexedQuery(
-	    $cf['cache']['index'],
+	    $cf['memcache']['index'],
 	    $cf['memcache']['connection'],
         $cf['mysql']['connection'], 
         'SELECT id, __label__ FROM tipologie_soddisfazione_view' );

--- a/_mod/_1100.attivita/_src/_inc/_macro/_attivita.form.php
+++ b/_mod/_1100.attivita/_src/_inc/_macro/_attivita.form.php
@@ -25,7 +25,7 @@
     /*
     // tendina tipologie pubblicazione
 	$ct['etc']['select']['tipologie_pubblicazione'] = mysqlCachedIndexedQuery(
-	    $cf['cache']['index'],
+	    $cf['memcache']['index'],
 	    $cf['memcache']['connection'],
 	    $cf['mysql']['connection'],
 	    'SELECT id, __label__ FROM tipologie_pubblicazione_view'
@@ -34,20 +34,20 @@
     
     // tendina anagrafica
 	$ct['etc']['select']['id_anagrafica'] = mysqlCachedIndexedQuery(
-	    $cf['cache']['index'],
+	    $cf['memcache']['index'],
 	    $cf['memcache']['connection'],
         $cf['mysql']['connection'], 
         'SELECT id, __label__ FROM anagrafica_view' );
 
 	if( isset( $_REQUEST[ $ct['form']['table'] ]['id_anagrafica'] ) ) {
 	    $ct['etc']['select']['id_anagrafica_collaboratori'] = mysqlCachedIndexedQuery(
-	        $cf['cache']['index'],
+	        $cf['memcache']['index'],
 	        $cf['memcache']['connection'],
             $cf['mysql']['connection'], 
             'SELECT id, __label__ FROM anagrafica_view WHERE se_collaboratore = 1 OR id = ?', array( array( 's' => $_REQUEST[ $ct['form']['table'] ]['id_anagrafica'] ) ) );
 	} else {
 	    $ct['etc']['select']['id_anagrafica_collaboratori'] = mysqlCachedIndexedQuery(
-            $cf['cache']['index'],
+            $cf['memcache']['index'],
             $cf['memcache']['connection'],
             $cf['mysql']['connection'], 
             'SELECT id, __label__ FROM anagrafica_view WHERE se_collaboratore = 1' );
@@ -55,42 +55,42 @@
 
     // tendina tipologia
 	$ct['etc']['select']['id_tipologia'] = mysqlCachedIndexedQuery(
-	    $cf['cache']['index'],
+	    $cf['memcache']['index'],
 	    $cf['memcache']['connection'],
         $cf['mysql']['connection'], 
         'SELECT id, __label__ FROM tipologie_attivita_view' );
 
     // tendina tipologia inps
 	$ct['etc']['select']['id_tipologia_inps'] = mysqlCachedIndexedQuery(
-	    $cf['cache']['index'],
+	    $cf['memcache']['index'],
 	    $cf['memcache']['connection'],
         $cf['mysql']['connection'], 
         'SELECT id, __label__ FROM tipologie_attivita_inps_view' );
 
     // tendina clienti
 	$ct['etc']['select']['id_cliente'] = mysqlCachedIndexedQuery(
-	    $cf['cache']['index'],
+	    $cf['memcache']['index'],
 	    $cf['memcache']['connection'],
         $cf['mysql']['connection'], 
         'SELECT id, __label__ FROM anagrafica_view WHERE se_lead = 1 OR se_cliente = 1 OR se_prospect = 1' );
 
     // tendina esiti
 	$ct['etc']['select']['id_esito'] = mysqlCachedIndexedQuery(
-	    $cf['cache']['index'],
+	    $cf['memcache']['index'],
 	    $cf['memcache']['connection'],
         $cf['mysql']['connection'], 
         'SELECT id, __label__ FROM esiti_attivita_view' );
 
     // tendina interesse
 	$ct['etc']['select']['id_interesse'] = mysqlCachedIndexedQuery(
-	    $cf['cache']['index'],
+	    $cf['memcache']['index'],
 	    $cf['memcache']['connection'],
         $cf['mysql']['connection'], 
         'SELECT id, __label__ FROM tipologie_interesse_view' );
 
     // tendina soddisfazione
 	$ct['etc']['select']['id_soddisfazione'] = mysqlCachedIndexedQuery(
-	    $cf['cache']['index'],
+	    $cf['memcache']['index'],
 	    $cf['memcache']['connection'],
         $cf['mysql']['connection'], 
         'SELECT id, __label__ FROM tipologie_soddisfazione_view' );
@@ -106,13 +106,13 @@
     // tendina progetti
 	if( isset( $_REQUEST[ $ct['form']['table'] ]['id_progetto'] ) ) {
 	    $ct['etc']['select']['id_progetto'] = mysqlCachedIndexedQuery(
-            $cf['cache']['index'],
+            $cf['memcache']['index'],
             $cf['memcache']['connection'],
             $cf['mysql']['connection'], 
             'SELECT id, concat( cliente, " | ", __label__ ) AS __label__ FROM progetti_view WHERE ( timestamp_chiusura IS NULL OR id = ? ) ORDER BY __label__', array( array( 's' => $_REQUEST[ $ct['form']['table'] ]['id_progetto'] ) ) );
 	} else {
 	    $ct['etc']['select']['id_progetto'] = mysqlCachedIndexedQuery(
-            $cf['cache']['index'],
+            $cf['memcache']['index'],
             $cf['memcache']['connection'],
             $cf['mysql']['connection'], 
             'SELECT id, concat( cliente, " | ", __label__ ) AS __label__ FROM progetti_view WHERE timestamp_chiusura IS NULL ORDER BY __label__' );
@@ -121,7 +121,7 @@
     // tendina todo
 	if( isset( $_REQUEST[ $ct['form']['table'] ]['id_progetto'] ) ) {
 	    $ct['etc']['select']['id_todo'] = mysqlCachedIndexedQuery(
-            $cf['cache']['index'],
+            $cf['memcache']['index'],
             $cf['memcache']['connection'],
             $cf['mysql']['connection'], 
             'SELECT id, __label__ FROM todo_view WHERE id_progetto = ? AND ( timestamp_completamento IS NULL OR id = ? )', 
@@ -131,7 +131,7 @@
             );
 	} else {
 	    $ct['etc']['select']['id_todo'] = mysqlCachedIndexedQuery(
-            $cf['cache']['index'],
+            $cf['memcache']['index'],
             $cf['memcache']['connection'],
             $cf['mysql']['connection'], 
             'SELECT id, __label__ FROM todo_view' );
@@ -139,7 +139,7 @@
 
     // tendina indirizzi
     $ct['etc']['select']['indirizzi'] = mysqlCachedIndexedQuery(
-	    $cf['cache']['index'],
+	    $cf['memcache']['index'],
 	    $cf['memcache']['connection'],
         $cf['mysql']['connection'], 
         'SELECT id, __label__ FROM indirizzi_view' );

--- a/_mod/_1100.attivita/_src/_inc/_macro/_turni.form.php
+++ b/_mod/_1100.attivita/_src/_inc/_macro/_turni.form.php
@@ -16,7 +16,7 @@
 
      // tendina contratti
     $ct['etc']['select']['contratti'] = mysqlCachedIndexedQuery(
-        $cf['cache']['index'],
+        $cf['memcache']['index'],
         $cf['memcache']['connection'],
         $cf['mysql']['connection'],
         'SELECT id, __label__ FROM contratti_view'
@@ -24,7 +24,7 @@
 
     // tendina anagrafica
     $ct['etc']['select']['anagrafica'] = mysqlCachedIndexedQuery(
-        $cf['cache']['index'],
+        $cf['memcache']['index'],
         $cf['memcache']['connection'],
         $cf['mysql']['connection'],
         'SELECT id, __label__ FROM anagrafica_view WHERE se_collaboratore = 1'

--- a/_mod/_1100.attivita/_src/_inc/_macro/_turni.tools.php
+++ b/_mod/_1100.attivita/_src/_inc/_macro/_turni.tools.php
@@ -19,7 +19,7 @@
 
     // tendina contratti
         $ct['etc']['select']['contratti'] = mysqlCachedIndexedQuery(
-        $cf['cache']['index'],
+        $cf['memcache']['index'],
         $cf['memcache']['connection'],
         $cf['mysql']['connection'],
         'SELECT id, __label__ FROM contratti_view'

--- a/_mod/_1100.attivita/_src/_inc/_macro/_turni.view.php
+++ b/_mod/_1100.attivita/_src/_inc/_macro/_turni.view.php
@@ -40,7 +40,7 @@
     
     // tendina contratti
     $ct['etc']['select']['contratti'] = mysqlCachedIndexedQuery(
-        $cf['cache']['index'],
+        $cf['memcache']['index'],
         $cf['memcache']['connection'],
         $cf['mysql']['connection'],
         'SELECT id, __label__ FROM contratti_view'
@@ -53,7 +53,7 @@
 
     // tendina pianificazioni
     $ct['etc']['select']['pianificazioni'] = mysqlCachedIndexedQuery(
-        $cf['cache']['index'],
+        $cf['memcache']['index'],
         $cf['memcache']['connection'],
         $cf['mysql']['connection'],
         'SELECT DISTINCT id_pianificazione AS id, id_pianificazione AS __label__ FROM turni WHERE id_pianificazione IS NOT NULL ORDER BY id_pianificazione'

--- a/_mod/_1140.variazioni/_src/_inc/_macro/_attivita.scoperte.form.php
+++ b/_mod/_1140.variazioni/_src/_inc/_macro/_attivita.scoperte.form.php
@@ -28,7 +28,7 @@
 
         // tendina operatori per settaggio manuale
 	    $ct['etc']['select']['operatori'] = mysqlCachedIndexedQuery(
-            $cf['cache']['index'],
+            $cf['memcache']['index'],
             $cf['memcache']['connection'],
             $cf['mysql']['connection'],
             "SELECT id, __label__ FROM anagrafica_view WHERE se_collaboratore = 1 AND "

--- a/_mod/_1140.variazioni/_src/_inc/_macro/_progetti.scoperti.form.php
+++ b/_mod/_1140.variazioni/_src/_inc/_macro/_progetti.scoperti.form.php
@@ -28,7 +28,7 @@
 
         // tendina operatori per settaggio manuale
 	    $ct['etc']['select']['operatori'] = mysqlCachedIndexedQuery(
-            $cf['cache']['index'],
+            $cf['memcache']['index'],
             $cf['memcache']['connection'],
             $cf['mysql']['connection'], 
             'SELECT id, __label__ FROM anagrafica_view WHERE se_collaboratore = 1' );

--- a/_mod/_1140.variazioni/_src/_inc/_macro/_variazioni.form.php
+++ b/_mod/_1140.variazioni/_src/_inc/_macro/_variazioni.form.php
@@ -24,21 +24,21 @@
 
     // tendina anagrafica
 	$ct['etc']['select']['operatori'] = mysqlCachedIndexedQuery(
-	    $cf['cache']['index'],
+	    $cf['memcache']['index'],
 	    $cf['memcache']['connection'],
         $cf['mysql']['connection'], 
         'SELECT id, __label__ FROM anagrafica_view WHERE se_collaboratore = 1' );
 
     // tendina tipologia
 	$ct['etc']['select']['tipologie'] = mysqlCachedIndexedQuery(
-	    $cf['cache']['index'],
+	    $cf['memcache']['index'],
 	    $cf['memcache']['connection'],
         $cf['mysql']['connection'], 
         'SELECT id, __label__ FROM tipologie_variazioni_attivita_view' );
 
     // tendina tipologia inps
 	$ct['etc']['select']['tipologie_inps'] = mysqlCachedIndexedQuery(
-	    $cf['cache']['index'],
+	    $cf['memcache']['index'],
 	    $cf['memcache']['connection'],
         $cf['mysql']['connection'], 
         'SELECT id, __label__ FROM tipologie_attivita_inps_view' );

--- a/_mod/_1140.variazioni/_src/_inc/_macro/_variazioni.tools.php
+++ b/_mod/_1140.variazioni/_src/_inc/_macro/_variazioni.tools.php
@@ -18,7 +18,7 @@
 
     // tendina progetti
 	$ct['etc']['select']['progetti'] = mysqlCachedIndexedQuery(
-        $cf['cache']['index'],
+        $cf['memcache']['index'],
         $cf['memcache']['connection'],
 	    $cf['mysql']['connection'],
 	    'SELECT id, __label__ FROM progetti_view'
@@ -26,7 +26,7 @@
 
     // tendina anagrafica
 	$ct['etc']['select']['anagrafica'] = mysqlCachedIndexedQuery(
-        $cf['cache']['index'],
+        $cf['memcache']['index'],
         $cf['memcache']['connection'],
 	    $cf['mysql']['connection'],
 	    'SELECT id, __label__ FROM anagrafica_view WHERE se_collaboratore = 1'

--- a/_mod/_1200.todo/_src/_inc/_macro/_todo.form.php
+++ b/_mod/_1200.todo/_src/_inc/_macro/_todo.form.php
@@ -24,33 +24,33 @@
 
     // tendina priorita
 	$ct['etc']['select']['id_priorita'] = mysqlCachedIndexedQuery(
-	    $cf['cache']['index'],
+	    $cf['memcache']['index'],
 	    $cf['memcache']['connection'],
         $cf['mysql']['connection'], 'SELECT id, __label__ FROM priorita_view' );
 
     // tendina tipologie
 	$ct['etc']['select']['tipologie'] = mysqlCachedIndexedQuery(
-	    $cf['cache']['index'],
+	    $cf['memcache']['index'],
 	    $cf['memcache']['connection'],
         $cf['mysql']['connection'], 'SELECT id, __label__ FROM tipologie_todo_view' );
     
     // tendina collaboratori
 	$ct['etc']['select']['id_anagrafica_collaboratori'] = mysqlCachedIndexedQuery(
-        $cf['cache']['index'],
+        $cf['memcache']['index'],
         $cf['memcache']['connection'],
         $cf['mysql']['connection'], 
         'SELECT id, __label__ FROM anagrafica_view WHERE se_collaboratore = 1' );
 	
     // tendina clienti
 	$ct['etc']['select']['id_cliente'] = mysqlCachedIndexedQuery(
-	    $cf['cache']['index'],
+	    $cf['memcache']['index'],
 	    $cf['memcache']['connection'],
         $cf['mysql']['connection'], 
         'SELECT id, __label__ FROM anagrafica_view WHERE se_lead = 1 OR se_cliente = 1 OR se_prospect = 1' );
 
     // tendina progetti
 	$ct['etc']['select']['id_progetto'] = mysqlCachedIndexedQuery(
-	    $cf['cache']['index'],
+	    $cf['memcache']['index'],
 	    $cf['memcache']['connection'],
         $cf['mysql']['connection'], 
         'SELECT id, __label__ FROM progetti_view' );
@@ -74,7 +74,7 @@
 	}
 
     $ct['etc']['select']['indirizzi'] = mysqlCachedIndexedQuery(
-	    $cf['cache']['index'],
+	    $cf['memcache']['index'],
 	    $cf['memcache']['connection'],
         $cf['mysql']['connection'], 
         'SELECT id, __label__ FROM indirizzi_view' );

--- a/_mod/_1200.todo/_src/_inc/_macro/_todo.view.php
+++ b/_mod/_1200.todo/_src/_inc/_macro/_todo.view.php
@@ -65,7 +65,7 @@
 
 	// tendina tipologie
 	$ct['etc']['select']['tipologie'] = mysqlCachedIndexedQuery(
-	    $cf['cache']['index'],
+	    $cf['memcache']['index'],
 	    $cf['memcache']['connection'],
         $cf['mysql']['connection'], 'SELECT id, __label__ FROM tipologie_todo_view' );
 

--- a/_mod/_2000.commerciale/_src/_inc/_macro/_progetti.commerciale.form.php
+++ b/_mod/_2000.commerciale/_src/_inc/_macro/_progetti.commerciale.form.php
@@ -24,14 +24,14 @@
     
     // tendina clienti
 	$ct['etc']['select']['clienti'] = mysqlCachedIndexedQuery(
-	    $cf['cache']['index'],
+	    $cf['memcache']['index'],
 	    $cf['memcache']['connection'],
         $cf['mysql']['connection'], 
         'SELECT id, __label__ FROM anagrafica_view WHERE se_cliente = 1' );
 
     // tendina anagrafica per referenti e operatori (TODO vedere se filtrare sui referenti del cliente)
     $ct['etc']['select']['anagrafica'] = mysqlCachedIndexedQuery(
-        $cf['cache']['index'],
+        $cf['memcache']['index'],
         $cf['memcache']['connection'],
         $cf['mysql']['connection'], 
         'SELECT id, __label__ FROM anagrafica_view WHERE se_collaboratore = 1 OR se_referente = 1' );
@@ -39,7 +39,7 @@
 
     // tendina indirizzi
 	$ct['etc']['select']['indirizzi'] = mysqlCachedIndexedQuery(
-	    $cf['cache']['index'],
+	    $cf['memcache']['index'],
 	    $cf['memcache']['connection'],
         $cf['mysql']['connection'], 
         'SELECT id, __label__ FROM indirizzi_view' );

--- a/_mod/_4000.catalogo/_src/_inc/_macro/_categorie.prodotti.form.audio.php
+++ b/_mod/_4000.catalogo/_src/_inc/_macro/_categorie.prodotti.form.audio.php
@@ -27,7 +27,7 @@
 
     // tendina ruolo video
 	$ct['etc']['select']['ruoli_audio'] = mysqlCachedIndexedQuery(
-	    $cf['cache']['index'],
+	    $cf['memcache']['index'],
 	    $cf['memcache']['connection'],
 	    $cf['mysql']['connection'],
 	    'SELECT id, __label__ FROM ruoli_audio_view WHERE se_categorie_prodotti = 1'
@@ -35,7 +35,7 @@
     
     // tendina tipologia embed
 	$ct['etc']['select']['tipologie_embed'] = mysqlCachedIndexedQuery(
-	    $cf['cache']['index'],
+	    $cf['memcache']['index'],
 	    $cf['memcache']['connection'],
 	    $cf['mysql']['connection'],
 	    'SELECT id, __label__ FROM tipologie_embed_view  WHERE se_audio = 1'

--- a/_mod/_4000.catalogo/_src/_inc/_macro/_categorie.prodotti.form.caratteristiche.php
+++ b/_mod/_4000.catalogo/_src/_inc/_macro/_categorie.prodotti.form.caratteristiche.php
@@ -24,7 +24,7 @@
 
     // tendina id caratteristiche
 	$ct['etc']['select']['id_caratteristiche'] = mysqlCachedIndexedQuery(
-	    $cf['cache']['index'],
+	    $cf['memcache']['index'],
 	    $cf['memcache']['connection'],
 	    $cf['mysql']['connection'],
         'SELECT id, __label__ FROM caratteristiche_prodotti_view'

--- a/_mod/_4000.catalogo/_src/_inc/_macro/_categorie.prodotti.form.file.php
+++ b/_mod/_4000.catalogo/_src/_inc/_macro/_categorie.prodotti.form.file.php
@@ -27,7 +27,7 @@
 
     // tendina ruolo immagini
 	$ct['etc']['select']['ruoli_file'] = mysqlCachedIndexedQuery(
-	    $cf['cache']['index'],
+	    $cf['memcache']['index'],
 	    $cf['memcache']['connection'],
 	    $cf['mysql']['connection'],
 	    'SELECT id, __label__ FROM ruoli_file_view WHERE se_categorie_prodotti = 1'

--- a/_mod/_4000.catalogo/_src/_inc/_macro/_categorie.prodotti.form.gruppi.php
+++ b/_mod/_4000.catalogo/_src/_inc/_macro/_categorie.prodotti.form.gruppi.php
@@ -24,7 +24,7 @@
     
     // tendina gruppi 
 	$ct['etc']['select']['gruppi'] = mysqlCachedIndexedQuery(
-	    $cf['cache']['index'],
+	    $cf['memcache']['index'],
 	    $cf['memcache']['connection'],
 	    $cf['mysql']['connection'],
         'SELECT id, __label__ FROM gruppi_view'

--- a/_mod/_4000.catalogo/_src/_inc/_macro/_categorie.prodotti.form.immagini.php
+++ b/_mod/_4000.catalogo/_src/_inc/_macro/_categorie.prodotti.form.immagini.php
@@ -27,7 +27,7 @@
 
     // tendina ruolo immagini
 	$ct['etc']['select']['ruoli_immagini'] = mysqlCachedIndexedQuery(
-	    $cf['cache']['index'],
+	    $cf['memcache']['index'],
 	    $cf['memcache']['connection'],
 	    $cf['mysql']['connection'],
 	    'SELECT id, __label__ FROM ruoli_immagini_view WHERE se_categorie_prodotti = 1'

--- a/_mod/_4000.catalogo/_src/_inc/_macro/_categorie.prodotti.form.php
+++ b/_mod/_4000.catalogo/_src/_inc/_macro/_categorie.prodotti.form.php
@@ -27,7 +27,7 @@
     
     // tendina id_genitore
 	$ct['etc']['select']['id_genitore'] = mysqlCachedIndexedQuery(
-	    $cf['cache']['index'],
+	    $cf['memcache']['index'],
 	    $cf['memcache']['connection'],
 	    $cf['mysql']['connection'],
 	    'SELECT id, __label__ FROM categorie_prodotti_view'
@@ -44,7 +44,7 @@
 
         // tendina genitori
 		$ct['etc']['select'][ $ct['form']['table'] ] = mysqlCachedIndexedQuery(
-            $cf['cache']['index'],
+            $cf['memcache']['index'],
             $cf['memcache']['connection'],
                 $cf['mysql']['connection'],
             'SELECT id, __label__ FROM pagine_view WHERE id_sito = ? AND pagine_path_check( pagine_view.id, ? ) = 0',
@@ -79,7 +79,7 @@
     
      // tendina id_tipologia_pubblicazione
 	$ct['etc']['select']['tipologie_pubblicazione'] = mysqlCachedIndexedQuery(
-	    $cf['cache']['index'],
+	    $cf['memcache']['index'],
 	    $cf['memcache']['connection'],
 	    $cf['mysql']['connection'],
 	    'SELECT id, __label__ FROM tipologie_pubblicazione_view'

--- a/_mod/_4000.catalogo/_src/_inc/_macro/_categorie.prodotti.form.video.php
+++ b/_mod/_4000.catalogo/_src/_inc/_macro/_categorie.prodotti.form.video.php
@@ -27,7 +27,7 @@
 
     // tendina ruolo video
 	$ct['etc']['select']['ruoli_video'] = mysqlCachedIndexedQuery(
-	    $cf['cache']['index'],
+	    $cf['memcache']['index'],
 	    $cf['memcache']['connection'],
 	    $cf['mysql']['connection'],
         'SELECT id, __label__ FROM ruoli_video_view WHERE se_categorie_prodotti = 1'
@@ -35,7 +35,7 @@
     
     // tendina tipologia embed
 	$ct['etc']['select']['tipologie_embed'] = mysqlCachedIndexedQuery(
-	    $cf['cache']['index'],
+	    $cf['memcache']['index'],
 	    $cf['memcache']['connection'],
 	    $cf['mysql']['connection'],
 	    'SELECT id, __label__ FROM tipologie_embed_view  WHERE se_video = 1'

--- a/_mod/_4100.prodotti/_src/_inc/_macro/_articoli.form.audio.php
+++ b/_mod/_4100.prodotti/_src/_inc/_macro/_articoli.form.audio.php
@@ -27,7 +27,7 @@
 
     // tendina ruolo video
 	$ct['etc']['select']['ruoli_audio'] = mysqlCachedIndexedQuery(
-	    $cf['cache']['index'],
+	    $cf['memcache']['index'],
 	    $cf['memcache']['connection'],
 	    $cf['mysql']['connection'],
 	    'SELECT id, __label__ FROM ruoli_audio_view WHERE se_articoli = 1'
@@ -35,7 +35,7 @@
     
     // tendina tipologia embed
 	$ct['etc']['select']['tipologie_embed'] = mysqlCachedIndexedQuery(
-	    $cf['cache']['index'],
+	    $cf['memcache']['index'],
 	    $cf['memcache']['connection'],
 	    $cf['mysql']['connection'],
 	    'SELECT id, __label__ FROM tipologie_embed_view'

--- a/_mod/_4100.prodotti/_src/_inc/_macro/_articoli.form.caratteristiche.php
+++ b/_mod/_4100.prodotti/_src/_inc/_macro/_articoli.form.caratteristiche.php
@@ -24,7 +24,7 @@
 
     // tendina caratteristiche
 	$ct['etc']['select']['caratteristiche'] = mysqlCachedIndexedQuery(
-	    $cf['cache']['index'],
+	    $cf['memcache']['index'],
 	    $cf['memcache']['connection'],
 	    $cf['mysql']['connection'],
         'SELECT id, __label__ FROM caratteristiche_prodotti_view'

--- a/_mod/_4100.prodotti/_src/_inc/_macro/_articoli.form.file.php
+++ b/_mod/_4100.prodotti/_src/_inc/_macro/_articoli.form.file.php
@@ -27,7 +27,7 @@
 
     // tendina ruolo immagini
 	$ct['etc']['select']['ruoli_file'] = mysqlCachedIndexedQuery(
-	    $cf['cache']['index'],
+	    $cf['memcache']['index'],
 	    $cf['memcache']['connection'],
 	    $cf['mysql']['connection'],
 	    'SELECT id, __label__ FROM ruoli_file_view WHERE se_articoli = 1'

--- a/_mod/_4100.prodotti/_src/_inc/_macro/_articoli.form.immagini.php
+++ b/_mod/_4100.prodotti/_src/_inc/_macro/_articoli.form.immagini.php
@@ -27,7 +27,7 @@
 
     // tendina ruolo immagini
 	$ct['etc']['select']['ruoli_immagini'] = mysqlCachedIndexedQuery(
-	    $cf['cache']['index'],
+	    $cf['memcache']['index'],
 	    $cf['memcache']['connection'],
 	    $cf['mysql']['connection'],
 	    'SELECT id, __label__ FROM ruoli_immagini_view WHERE se_articoli = 1'

--- a/_mod/_4100.prodotti/_src/_inc/_macro/_articoli.form.php
+++ b/_mod/_4100.prodotti/_src/_inc/_macro/_articoli.form.php
@@ -24,21 +24,21 @@
 
     // tendina prodotti
 	$ct['etc']['select']['prodotti'] = mysqlCachedIndexedQuery(
-	    $cf['cache']['index'],
+	    $cf['memcache']['index'],
 	    $cf['memcache']['connection'],
         $cf['mysql']['connection'], 
         'SELECT id, __label__ FROM prodotti_view' );
 
     // tendina colori
 	$ct['etc']['select']['colori'] = mysqlCachedIndexedQuery(
-	    $cf['cache']['index'],
+	    $cf['memcache']['index'],
 	    $cf['memcache']['connection'],
         $cf['mysql']['connection'], 
         'SELECT id, __label__ FROM colori_view' );
 
     // tendina id_tipologia_pubblicazione
 	$ct['etc']['select']['tipologie_pubblicazione'] = mysqlCachedIndexedQuery(
-	    $cf['cache']['index'],
+	    $cf['memcache']['index'],
 	    $cf['memcache']['connection'],
 	    $cf['mysql']['connection'],
 	    'SELECT id, __label__ FROM tipologie_pubblicazione_view'
@@ -46,14 +46,14 @@
 
     // tendina taglie
 	$ct['etc']['select']['taglie'] = mysqlCachedIndexedQuery(
-	    $cf['cache']['index'],
+	    $cf['memcache']['index'],
 	    $cf['memcache']['connection'], 
         $cf['mysql']['connection'], 
         'SELECT id, __label__ FROM taglie_view' );
 
     // tendina unità di misura
 	$ct['etc']['select']['udm'] = mysqlCachedIndexedQuery(
-	    $cf['cache']['index'],
+	    $cf['memcache']['index'],
 	    $cf['memcache']['connection'], 
         $cf['mysql']['connection'], 
         'SELECT id, __label__ FROM udm_view' );

--- a/_mod/_4100.prodotti/_src/_inc/_macro/_articoli.form.prezzi.php
+++ b/_mod/_4100.prodotti/_src/_inc/_macro/_articoli.form.prezzi.php
@@ -27,14 +27,14 @@
 
     // tendina listini
 	$ct['etc']['select']['listini'] = mysqlCachedIndexedQuery(
-	    $cf['cache']['index'],
+	    $cf['memcache']['index'],
         $cf['memcache']['connection'], 
         $cf['mysql']['connection'], 
         'SELECT id, __label__ FROM listini_view' );
 
     // tendina IVA
 	$ct['etc']['select']['iva'] = mysqlCachedIndexedQuery(
-	    $cf['cache']['index'],
+	    $cf['memcache']['index'],
         $cf['memcache']['connection'],
         $cf['mysql']['connection'], 
         'SELECT id, __label__ FROM iva_view' );

--- a/_mod/_4100.prodotti/_src/_inc/_macro/_articoli.form.video.php
+++ b/_mod/_4100.prodotti/_src/_inc/_macro/_articoli.form.video.php
@@ -27,7 +27,7 @@
 
     // tendina ruolo video
 	$ct['etc']['select']['ruoli_video'] = mysqlCachedIndexedQuery(
-	    $cf['cache']['index'],
+	    $cf['memcache']['index'],
 	    $cf['memcache']['connection'],
 	    $cf['mysql']['connection'],
         'SELECT id, __label__ FROM ruoli_video_view WHERE se_articoli = 1'
@@ -35,7 +35,7 @@
     
     // tendina tipologia embed
 	$ct['etc']['select']['tipologie_embed'] = mysqlCachedIndexedQuery(
-	    $cf['cache']['index'],
+	    $cf['memcache']['index'],
 	    $cf['memcache']['connection'],
 	    $cf['mysql']['connection'],
 	    'SELECT id, __label__ FROM tipologie_embed_view'

--- a/_mod/_4100.prodotti/_src/_inc/_macro/_listini.form.gruppi.php
+++ b/_mod/_4100.prodotti/_src/_inc/_macro/_listini.form.gruppi.php
@@ -24,7 +24,7 @@
     
     // tendina gruppi 
 	$ct['etc']['select']['gruppi'] = mysqlCachedIndexedQuery(
-	    $cf['cache']['index'],
+	    $cf['memcache']['index'],
 	    $cf['memcache']['connection'],
 	    $cf['mysql']['connection'],
         'SELECT id, __label__ FROM gruppi_view'

--- a/_mod/_4100.prodotti/_src/_inc/_macro/_listini.form.php
+++ b/_mod/_4100.prodotti/_src/_inc/_macro/_listini.form.php
@@ -24,7 +24,7 @@
 
     // tendina unità di misura
 	$ct['etc']['select']['valute'] = mysqlCachedIndexedQuery(
-	    $cf['cache']['index'],
+	    $cf['memcache']['index'],
 	    $cf['memcache']['connection'], 
         $cf['mysql']['connection'], 
         'SELECT id, __label__ FROM valute_view' );

--- a/_mod/_4100.prodotti/_src/_inc/_macro/_prodotti.form.audio.php
+++ b/_mod/_4100.prodotti/_src/_inc/_macro/_prodotti.form.audio.php
@@ -27,7 +27,7 @@
 
     // tendina ruolo video
 	$ct['etc']['select']['ruoli_audio'] = mysqlCachedIndexedQuery(
-	    $cf['cache']['index'],
+	    $cf['memcache']['index'],
 	    $cf['memcache']['connection'],
 	    $cf['mysql']['connection'],
 	    'SELECT id, __label__ FROM ruoli_audio_view WHERE se_prodotti = 1'
@@ -35,7 +35,7 @@
     
     // tendina tipologia embed
 	$ct['etc']['select']['tipologie_embed'] = mysqlCachedIndexedQuery(
-	    $cf['cache']['index'],
+	    $cf['memcache']['index'],
 	    $cf['memcache']['connection'],
 	    $cf['mysql']['connection'],
 	    'SELECT id, __label__ FROM tipologie_embed_view'

--- a/_mod/_4100.prodotti/_src/_inc/_macro/_prodotti.form.caratteristiche.php
+++ b/_mod/_4100.prodotti/_src/_inc/_macro/_prodotti.form.caratteristiche.php
@@ -32,7 +32,7 @@
 
     // tendina caratteristiche
 	$ct['etc']['select']['caratteristiche'] = mysqlCachedIndexedQuery(
-	    $cf['cache']['index'],
+	    $cf['memcache']['index'],
 	    $cf['memcache']['connection'],
 	    $cf['mysql']['connection'],
         'SELECT id, __label__ FROM caratteristiche_prodotti_view'
@@ -40,7 +40,7 @@
 
     // tendina stagioni
 	$ct['etc']['select']['stagioni'] = mysqlCachedIndexedQuery(
-	    $cf['cache']['index'],
+	    $cf['memcache']['index'],
 	    $cf['memcache']['connection'],
 	    $cf['mysql']['connection'],
         'SELECT id, __label__ FROM stagioni_prodotti_view'

--- a/_mod/_4100.prodotti/_src/_inc/_macro/_prodotti.form.categorie.php
+++ b/_mod/_4100.prodotti/_src/_inc/_macro/_prodotti.form.categorie.php
@@ -24,7 +24,7 @@
 
     // tendina categorie
 	$ct['etc']['select']['categorie'] = mysqlCachedIndexedQuery(
-	    $cf['cache']['index'],
+	    $cf['memcache']['index'],
 	    $cf['memcache']['connection'],
 	    $cf['mysql']['connection'],
         'SELECT id, __label__ FROM categorie_prodotti_view'

--- a/_mod/_4100.prodotti/_src/_inc/_macro/_prodotti.form.file.php
+++ b/_mod/_4100.prodotti/_src/_inc/_macro/_prodotti.form.file.php
@@ -27,7 +27,7 @@
 
     // tendina ruolo immagini
 	$ct['etc']['select']['ruoli_file'] = mysqlCachedIndexedQuery(
-	    $cf['cache']['index'],
+	    $cf['memcache']['index'],
 	    $cf['memcache']['connection'],
 	    $cf['mysql']['connection'],
 	    'SELECT id, __label__ FROM ruoli_file_view WHERE se_prodotti = 1'

--- a/_mod/_4100.prodotti/_src/_inc/_macro/_prodotti.form.immagini.php
+++ b/_mod/_4100.prodotti/_src/_inc/_macro/_prodotti.form.immagini.php
@@ -27,7 +27,7 @@
 
     // tendina ruolo immagini
 	$ct['etc']['select']['ruoli_immagini'] = mysqlCachedIndexedQuery(
-	    $cf['cache']['index'],
+	    $cf['memcache']['index'],
 	    $cf['memcache']['connection'],
 	    $cf['mysql']['connection'],
 	    'SELECT id, __label__ FROM ruoli_immagini_view WHERE se_prodotti = 1'

--- a/_mod/_4100.prodotti/_src/_inc/_macro/_prodotti.form.php
+++ b/_mod/_4100.prodotti/_src/_inc/_macro/_prodotti.form.php
@@ -44,7 +44,7 @@
 */
     // tendina produttori
 	$ct['etc']['select']['produttori'] = mysqlCachedIndexedQuery(
-	    $cf['cache']['index'],
+	    $cf['memcache']['index'],
 	    $cf['memcache']['connection'],
 	    $cf['mysql']['connection'],
         'SELECT id, __label__ FROM anagrafica_view WHERE se_produttore = 1' 
@@ -52,7 +52,7 @@
 
     // tendina marchi
 	$ct['etc']['select']['marchi'] = mysqlCachedIndexedQuery(
-	    $cf['cache']['index'],
+	    $cf['memcache']['index'],
 	    $cf['memcache']['connection'],
 	    $cf['mysql']['connection'],
         'SELECT id, __label__ FROM marchi_view' 
@@ -60,7 +60,7 @@
 
      // tendina tipologie
 	$ct['etc']['select']['tipologie'] = mysqlCachedIndexedQuery(
-	    $cf['cache']['index'],
+	    $cf['memcache']['index'],
 	    $cf['memcache']['connection'],
 	    $cf['mysql']['connection'], 
         'SELECT id, __label__ FROM tipologie_prodotti_view' 
@@ -68,7 +68,7 @@
     
      // tendina id_tipologia_pubblicazione
 	$ct['etc']['select']['tipologie_pubblicazione'] = mysqlCachedIndexedQuery(
-	    $cf['cache']['index'],
+	    $cf['memcache']['index'],
 	    $cf['memcache']['connection'],
 	    $cf['mysql']['connection'],
 	    'SELECT id, __label__ FROM tipologie_pubblicazione_view'
@@ -76,7 +76,7 @@
 
     // tendina unità di misura
 	$ct['etc']['select']['udm'] = mysqlCachedIndexedQuery(
-	    $cf['cache']['index'],
+	    $cf['memcache']['index'],
 	    $cf['memcache']['connection'], 
         $cf['mysql']['connection'], 
         'SELECT id, __label__ FROM udm_view' );

--- a/_mod/_4100.prodotti/_src/_inc/_macro/_prodotti.form.prezzi.php
+++ b/_mod/_4100.prodotti/_src/_inc/_macro/_prodotti.form.prezzi.php
@@ -27,14 +27,14 @@
 
     // tendina listini
 	$ct['etc']['select']['listini'] = mysqlCachedIndexedQuery(
-	    $cf['cache']['index'],
+	    $cf['memcache']['index'],
         $cf['memcache']['connection'], 
         $cf['mysql']['connection'], 
         'SELECT id, __label__ FROM listini_view' );
 
     // tendina IVA
 	$ct['etc']['select']['iva'] = mysqlCachedIndexedQuery(
-	    $cf['cache']['index'],
+	    $cf['memcache']['index'],
         $cf['memcache']['connection'],
         $cf['mysql']['connection'], 
         'SELECT id, __label__ FROM iva_view' );

--- a/_mod/_4100.prodotti/_src/_inc/_macro/_prodotti.form.video.php
+++ b/_mod/_4100.prodotti/_src/_inc/_macro/_prodotti.form.video.php
@@ -27,7 +27,7 @@
 
     // tendina ruolo video
 	$ct['etc']['select']['ruoli_video'] = mysqlCachedIndexedQuery(
-	    $cf['cache']['index'],
+	    $cf['memcache']['index'],
 	    $cf['memcache']['connection'],
 	    $cf['mysql']['connection'],
         'SELECT id, __label__ FROM ruoli_video_view WHERE se_prodotti = 1'
@@ -35,7 +35,7 @@
     
     // tendina tipologia embed
 	$ct['etc']['select']['tipologie_embed'] = mysqlCachedIndexedQuery(
-	    $cf['cache']['index'],
+	    $cf['memcache']['index'],
 	    $cf['memcache']['connection'],
 	    $cf['mysql']['connection'],
 	    'SELECT id, __label__ FROM tipologie_embed_view'

--- a/_mod/_6600.contratti/_src/_inc/_macro/_contratti.form.disponibilita.php
+++ b/_mod/_6600.contratti/_src/_inc/_macro/_contratti.form.disponibilita.php
@@ -19,7 +19,7 @@
     // tendina per i costi contratto
     if( isset( $_REQUEST['contratti']['id'] ) ) {
         $ct['etc']['select']['costi_contratti'] = mysqlCachedIndexedQuery(
-            $cf['cache']['index'],
+            $cf['memcache']['index'],
             $cf['memcache']['connection'],
             $cf['mysql']['connection'],
             'SELECT id, __label__ FROM costi_contratti_view WHERE id_contratto = ?',

--- a/_mod/_6600.contratti/_src/_inc/_macro/_contratti.form.orari.php
+++ b/_mod/_6600.contratti/_src/_inc/_macro/_contratti.form.orari.php
@@ -19,7 +19,7 @@
     // tendina per i costi contratto
     if( isset( $_REQUEST['contratti']['id'] ) ) {
         $ct['etc']['select']['costi_contratti'] = mysqlCachedIndexedQuery(
-            $cf['cache']['index'],
+            $cf['memcache']['index'],
             $cf['memcache']['connection'],
             $cf['mysql']['connection'],
             'SELECT id, __label__ FROM costi_contratti_view WHERE id_contratto = ?',

--- a/_mod/_6600.contratti/_src/_inc/_macro/_contratti.form.php
+++ b/_mod/_6600.contratti/_src/_inc/_macro/_contratti.form.php
@@ -16,7 +16,7 @@
 
      // tendina anagrafica
 	$ct['etc']['select']['anagrafica'] = mysqlCachedIndexedQuery(
-	    $cf['cache']['index'],
+	    $cf['memcache']['index'],
 	    $cf['memcache']['connection'],
 	    $cf['mysql']['connection'],
 	    'SELECT id, __label__ FROM anagrafica_view WHERE se_collaboratore = 1 OR se_dipendente = 1 OR se_interinale = 1'
@@ -24,7 +24,7 @@
 
     // tendina agenzia
 	$ct['etc']['select']['agenzia'] = mysqlCachedIndexedQuery(
-	    $cf['cache']['index'],
+	    $cf['memcache']['index'],
 	    $cf['memcache']['connection'],
 	    $cf['mysql']['connection'],
 	    'SELECT id, __label__ FROM anagrafica_view WHERE se_agenzia_interinale = 1'
@@ -32,7 +32,7 @@
     
     // tendina per le tipologie di contratto
     $ct['etc']['select']['tipologie_contratti'] = mysqlCachedIndexedQuery(
-	    $cf['cache']['index'],
+	    $cf['memcache']['index'],
 	    $cf['memcache']['connection'],
 	    $cf['mysql']['connection'],
 	    'SELECT id, __label__ FROM tipologie_contratti_view'
@@ -40,7 +40,7 @@
     
     // tendina per le tipologie di attività inps
     $ct['etc']['select']['tipologie_attivita_inps'] = mysqlCachedIndexedQuery(
-	    $cf['cache']['index'],
+	    $cf['memcache']['index'],
 	    $cf['memcache']['connection'],
 	    $cf['mysql']['connection'],
 	    'SELECT id, __label__ FROM tipologie_attivita_inps_view'
@@ -48,7 +48,7 @@
 
     // tendina per le tipologie di qualifiche inps
     $ct['etc']['select']['tipologie_qualifiche_inps'] = mysqlCachedIndexedQuery(
-	    $cf['cache']['index'],
+	    $cf['memcache']['index'],
 	    $cf['memcache']['connection'],
 	    $cf['mysql']['connection'],
 	    'SELECT id, __label__ FROM tipologie_qualifiche_inps_view'
@@ -56,7 +56,7 @@
 
     // tendina per le tipologie di durate inps
     $ct['etc']['select']['tipologie_durate_inps'] = mysqlCachedIndexedQuery(
-	    $cf['cache']['index'],
+	    $cf['memcache']['index'],
 	    $cf['memcache']['connection'],
 	    $cf['mysql']['connection'],
 	    'SELECT id, __label__ FROM tipologie_durate_inps_view'
@@ -64,7 +64,7 @@
 
     // tendina per le tipologie di orari inps
     $ct['etc']['select']['tipologie_orari_inps'] = mysqlCachedIndexedQuery(
-	    $cf['cache']['index'],
+	    $cf['memcache']['index'],
 	    $cf['memcache']['connection'],
 	    $cf['mysql']['connection'],
 	    'SELECT id, __label__ FROM tipologie_orari_inps_view'

--- a/_src/_inc/_macro/_anagrafica.form.amministrazione.php
+++ b/_src/_inc/_macro/_anagrafica.form.amministrazione.php
@@ -41,7 +41,7 @@
     
     // tendina condizioni pagamento
 	$ct['etc']['select']['condizioni_pagamento'] = mysqlCachedIndexedQuery(
-	    $cf['cache']['index'],
+	    $cf['memcache']['index'],
 	    $cf['memcache']['connection'],
 	    $cf['mysql']['connection'],
 	    'SELECT id, __label__ FROM condizioni_pagamento_view'
@@ -49,7 +49,7 @@
     
     // tendina modalità pagamento
 	$ct['etc']['select']['modalita_pagamento'] = mysqlCachedIndexedQuery(
-	    $cf['cache']['index'],
+	    $cf['memcache']['index'],
 	    $cf['memcache']['connection'],
 	    $cf['mysql']['connection'],
 	    'SELECT id, __label__ FROM modalita_pagamento_view'


### PR DESCRIPTION
corretto errore in diverse chiamate alla funzione mysqlCachedIndexedQuery, il primo parametro passato era _$cf['cache']['index']_ invece di _$cf['memcache']['index']_