### PR TITLE
Feature/sostituzioni per operatore e periodo

### DIFF
--- a/_mod/_1000.produzione/_src/_lib/_mysql.utils.php
+++ b/_mod/_1000.produzione/_src/_lib/_mysql.utils.php
@@ -372,140 +372,7 @@
         
     }
 
-    // funzione che data un'attività, ritorna l'elenco degli operatori che possono coprirla per una sostituzione con relativo punteggio
-/*    function elencoSostitutiAttivita( $id_attivita ){
-
-        global $cf;
-
-        // estraggo i dati che mi occorrono per l'attività
-        $a = mysqlSelectRow(
-            $cf['mysql']['connection'],
-            "SELECT id, id_progetto, data_programmazione, ora_inizio_programmazione, ora_fine_programmazione, TIMESTAMP( data_programmazione, ora_inizio_programmazione) as data_ora_inizio, "
-            ."TIMESTAMP( data_programmazione, ora_fine_programmazione) as data_ora_fine FROM attivita "
-            ."WHERE id = ?",
-            array(
-                array( 's' => $id_attivita )
-            )
-        );
-
-        // operatori che di base sono assegnati alle sostituzioni
-        // sono esclusi quelli per cui esiste una riga nella tabella sostituzioni_attivita per l'attivita corrente      
-        $sostituti = mysqlQuery(
-            $cf['mysql']['connection'],
-            'SELECT id AS id_anagrafica, __label__ as anagrafica, se_sostituto FROM anagrafica_view_static WHERE se_sostituto = 1 '
-            .'AND id NOT IN ( SELECT id_anagrafica FROM sostituzioni_attivita WHERE id_attivita = ? ) ',
-            array(
-                array( 's' => $id_attivita )
-            )
-        );
-
-        if( !empty( $sostituti ) ){
-            foreach( $sostituti as $s ){
-                $operatori[ $s['id_anagrafica'] ] = $s;
-            } 
-        }
-
-        // elenco di 30 operatori che hanno svolto attività in passato con priorità per quelli che hanno già lavorato al progetto
-        // esclusi quelli per cui esiste una riga nella tabella sostituzioni_attivita per l'attivita corrente
-        $assegnati = mysqlQuery(
-            $cf['mysql']['connection'],
-            'SELECT a.id_anagrafica, a.anagrafica, max(ca.se_sostituto) as se_sostituto, progetti.id as esperienza FROM attivita_view_static AS a '
-            .'LEFT JOIN anagrafica_categorie AS ac ON a.id_anagrafica = ac.id_anagrafica '
-            .'LEFT JOIN categorie_anagrafica AS ca ON ac.id_categoria = ca.id '
-            .'LEFT JOIN progetti ON a.id_progetto = progetti.id AND progetti.id = ? '
-            #.'INNER JOIN contratti as c ON (a.id_anagrafica = c.id_anagrafica AND (c.data_fine IS NULL OR c.data_fine > ?) ) '
-			.'INNER JOIN contratti as c ON (a.id_anagrafica = c.id_anagrafica AND (c.data_fine_rapporto IS NULL AND ( c.data_fine IS NULL OR c.data_fine >= ? ) ) ) '
-            .'WHERE a.id_anagrafica IS NOT NULL AND a.data_programmazione < ? AND a.id_anagrafica NOT IN ( SELECT id_anagrafica FROM sostituzioni_attivita WHERE id_attivita = ? ) '
-            .'GROUP BY a.id_anagrafica ORDER BY esperienza DESC LIMIT 15',
-            array(
-                array( 's' => $a['id_progetto'] ),
-                array( 's' => $a['data_programmazione'] ),
-                array( 's' => $a['data_programmazione'] ),
-                array( 's' => $id_attivita )
-            )
-        );
-
-        if( !empty( $assegnati ) ){
-            foreach( $assegnati as $as ){
-                $operatori[ $as['id_anagrafica'] ] = $as;
-            }
-        }
-
-        $candidati = array();
-        $op = array();      // array provvisorio
-
-        if( !empty( $operatori ) ){
-            foreach( $operatori as $k => $o ){
-                
-                // calcolo se può coprire l'attività
-                $copertura = coperturaAttivita( $o['id_anagrafica'], $id_attivita );
-                
-                // se non può coprirla rimuovo l'operatore dall'array e inserisco una riga di sostituzioni_attivita come scarto
-                // in modo che al prossimo giro non considererà più questo operatore
-                if( $copertura == 0 ){
-
-                    // chiamo il task che inserisce la riga di scarto
-                    restcall(
-                        $cf['site']['url'] . '_mod/_1140.variazioni/_src/_api/_task/_operatori.descard.php?id_anagrafica=' . $o['id_anagrafica'] . '&id_attivita=' . $id_attivita
-                    );
-                    unset( $operatori[$k] );
-                }
-                else{
-
-                    $o['punteggio'] = 0;
-
-                    if( $o['se_sostituto'] == 1 ){
-                        $o['punti_sostituto'] = 100;
-                    }
-                    else{
-                        $o['punti_sostituto'] = 0;
-                    }
-
-                    $o['punteggio'] += $o['punti_sostituto'];
-                        
-                // calcolo punteggi vari con le funzioni
-                    $o['punti_progetto'] = puntiConoscenzaProgetto( $o['id_anagrafica'], $a['id_progetto'], $a['data_programmazione']);
-                    $o['punti_disponibilita'] = puntiDisponibilitaOperatore( $o['id_anagrafica'], $a['data_programmazione'], $a['ora_inizio_programmazione'], $a['ora_fine_programmazione'] );
-                    $o['punti_distanza'] = intval( puntiDistanzaAttivita( $o['id_anagrafica'], $a['id'] ) );
-                    
-                    $o['punteggio'] += $o['punti_progetto'];
-                    $o['punteggio'] += $o['punti_disponibilita'];
-                    $o['punteggio'] += $o['punti_distanza'];
-                    
-                    // TODO: prevedere parte per audit qualità e blocchi (es. il cliente non vuole quell'operatore, ecc.)
-
-                    $op[ $o['id_anagrafica'] ] = $o;
-                }
-
-            }
-        }
-
-        // riordino l'array degli operatori in base al punteggio
-        $sort_data = array();
-        foreach( $op as $key => $value ) {
-            $sort_data[ $key ] = $value['punteggio'];
-        }
-
-        if( isset( $sort_data ) ){
-            array_multisort( $sort_data, $op );
-        }
-
-        foreach( $op as $o ){
-            while( array_key_exists( $o['punteggio'], $candidati ) ){
-                $o['punteggio']++;
-            }
-
-            $candidati[ $o['punteggio'] ] = $o;
-        }
-
-        krsort( $candidati );
-
-        return $candidati;
-
-    }
-*/
-
-
+    // funzione che calcola l'elenco dei possibili sostituti per un'attività
     function sostitutiAttivita( $id_attivita ){
 
         global $cf;
@@ -521,8 +388,6 @@
                 array( 's' => $id_attivita )
             )
         );
-
-    //    print_r($a);
 
         // elenco degli operatori disponibili che non sono già stati analizzati
         $operatori = mysqlQuery(
@@ -621,262 +486,8 @@
     }
 
 
-
-
-
-    // funzione che dato un progetto, calcola l'elenco degli operatori che possono coprirne le attività scoperte con relativo punteggio
-/*    function elencoSostitutiProgetto( $id_progetto ){
-
-        $logdir = 'var/log/sostitutiProgetto.log';
-
-        appendToFile('cerco sostituti progetto ' . $id_progetto . PHP_EOL, $logdir);
-
-        global $cf;
-
-        $candidati = array();   // inizializzo l'array del risultato
-        $op = array();      // array provvisorio per l'ordinamento
-
-        // data di pianificazione della prima attività scoperta per il progetto corrente
-        $dataPrima = mysqlSelectValue(
-            $cf['mysql']['connection'],
-            'SELECT min(data_programmazione) FROM attivita WHERE id_progetto = ? AND id_anagrafica IS NULL',
-            array(
-                array( 's' => $id_progetto )
-            )
-        );
-        
-        // data di pianificazione dell'ultima attività scoperta per il progetto corrente
-        $dataUltima = mysqlSelectValue(
-            $cf['mysql']['connection'],
-            'SELECT max(data_programmazione) FROM attivita WHERE id_progetto = ? AND id_anagrafica IS NULL',
-            array(
-                array( 's' => $id_progetto )
-            )
-        );
-
-        // operatori che di base sono assegnati alle sostituzioni
-        $sostituti = mysqlQuery(
-            $cf['mysql']['connection'],
-            'SELECT id AS id_anagrafica, __label__ as anagrafica, se_sostituto FROM anagrafica_view_static WHERE se_sostituto = 1'
-        );
-
-        if( !empty( $sostituti ) ){
-            foreach( $sostituti as $s ){
-                $operatori[ $s['id_anagrafica'] ] = $s;
-            } 
-        }
-
-        appendToFile('sostituti ' . print_r( $sostituti, true ) . PHP_EOL, $logdir);
-
-        timerCheck( $cf['speed'], 'inizio ricerca assegnati');
-
-        // elenco degli operatori che hanno attivita assegnate prima della prima scopertura e non sono già stati scartati, con priorità per quelli che conoscono già il progetto
-        $assegnati = mysqlQuery(
-            $cf['mysql']['connection'],
-            'SELECT a.id_anagrafica, a.anagrafica, max(ca.se_sostituto) as se_sostituto, progetti.id as esperienza FROM attivita_view_static AS a '
-            .'LEFT JOIN anagrafica_categorie AS ac ON a.id_anagrafica = ac.id_anagrafica '
-            .'LEFT JOIN categorie_anagrafica AS ca ON ac.id_categoria = ca.id '
-            .'LEFT JOIN progetti ON a.id_progetto = progetti.id AND progetti.id = ? '
-            #.'INNER JOIN contratti as c ON (a.id_anagrafica = c.id_anagrafica AND (c.data_fine IS NULL OR c.data_fine > ?) ) '
-			.'INNER JOIN contratti as c ON (a.id_anagrafica = c.id_anagrafica AND (c.data_fine_rapporto IS NULL AND ( c.data_fine IS NULL OR c.data_fine >= ? ) ) ) '
-            .'WHERE a.id_anagrafica IS NOT NULL AND a.data_programmazione < ? '
-            .'AND a.id_anagrafica NOT IN ( SELECT id_anagrafica FROM sostituzioni_progetti WHERE id_progetto = ? AND data_scopertura = ? ) '
-            .'GROUP BY a.id_anagrafica ORDER BY esperienza DESC, a.data_programmazione DESC LIMIT 20',
-            array(
-                array( 's' => $id_progetto ),
-                array( 's' => $dataPrima ),
-                array( 's' => $dataPrima ),
-                array( 's' => $id_progetto ),
-                array( 's' => $dataUltima )
-            )
-        );
-
-        appendToFile('assegnati ' . print_r( $assegnati, true ) . PHP_EOL, $logdir);
-
-        timerCheck( $cf['speed'], 'fine ricerca assegnati');
-    
-        if( !empty( $assegnati ) ){
-            foreach( $assegnati as $a ){
-                $operatori[ $a['id_anagrafica'] ] = $a;
-            }
-        }
-
-        timerCheck( $cf['speed'], 'inizio ricerca attivita scoperte');
-
-        // elenco delle attività scoperte per il progetto corrente
-        $attivita = mysqlQuery( 
-            $cf['mysql']['connection'],
-            'SELECT * FROM attivita WHERE id_progetto = ? AND id_anagrafica IS NULL',
-            array(
-                array( 's' => $id_progetto )
-            )
-        );
-
-        timerCheck( $cf['speed'], 'fine ricerca attivita scoperte');
-
-        timerCheck( $cf['speed'], 'inizio calcolo punteggi');
-
-        // se ci sono operatori candidati calcolo i punteggi
-        if( !empty( $operatori ) ){
-
-            // per ciascun operatore
-            foreach( $operatori as $o ){
-
-                appendToFile('operatore ' . $o['id_anagrafica'] . ' ' . $o['anagrafica'] . PHP_EOL, $logdir);
-                // scorro le attività e vedo se può coprirle
-
-                $o['punteggio'] = 0;
-                $o['punti_distanza'] = 0;
-                $o['punti_attivita'] = 0;
-                $o['punti_distanza_attivita'] = 0;
-
-                if( $o['se_sostituto'] == 1 ){
-                    $o['punti_sostituto'] = 100;
-                }
-                else{
-                    $o['punti_sostituto'] = 0;
-                }
-
-                $o['punteggio'] += $o['punti_sostituto'];
-
-                $attivita_coperte = 0;
-                $richieste_inviate = 0;
-
-                $svr = array();     //
-
-                foreach( $attivita as $a ){
-                    appendToFile('attivita ' . $a['id'] . PHP_EOL, $logdir);
-                    //14:00-15:45 2021-04-07 > ragionare a intervalli di 15 minuti, no ora inizio
-                //    $a['range'] = array( '202104071430', '202104071500', '202104071530', '202104071600');
-
-                    $inizio = strtotime( $a['ora_inizio_programmazione'] );
-                    $fine = strtotime( $a['ora_fine_programmazione'] );
-                    $a['range'] = array();
-                    $step = $inizio;
-                
-                    while( $step >= $inizio && $step <= $fine ){
-                        $step = strtotime("+15 minutes", $step);
-                        $a['range'][] = str_replace('-', '', $a['data_programmazione'] ) . str_replace(':', '', date('H:i', $step) );
-                    }
-
-                    $copertura = coperturaAttivita( $o['id_anagrafica'], $a['id'] );
-
-                    appendToFile('copertura ' . $copertura . PHP_EOL, $logdir);
-
-                    #appendToFile('count_intersect ' . $copertura . PHP_EOL, $logdir);count( array_intersect( $svr, $a['range'] ) )
-
-                    // se può coprire l'attività e non ci sono sovrapposizioni con altre fasce orarie
-                    if(  $copertura == 1 && count( array_intersect( $svr, $a['range'] ) ) == 0 ){
-
-                        $svr = array_merge( $a['range'], $svr );
-
-                        $o['punti_attivita']++;
-                        $o['punti_distanza_attivita'] += puntiDistanzaAttivita( $o['id_anagrafica'], $a['id'] );
-
-                        // verifico se c'è già una richiesta di sostituzione per essa
-                        $richieste = mysqlSelectValue(
-                            $cf['mysql']['connection'],
-                            'SELECT count(*) FROM sostituzioni_attivita WHERE id_attivita = ? '
-                            .'AND id_anagrafica = ?',
-                            array(
-                                array( 's' => $a['id'] ),
-                                array( 's' => $o['id_anagrafica'] )
-                            )
-                        );
-
-                        if( !empty( $richieste ) ){
-                            $richieste_inviate++;                          
-                        }
-                        
-                    }
-                   
-                }
-
-                // se i punti attività sono ancora a 0 vuol dire che non può coprire nessuna attività
-                // lo inserisco quindi nella tabella di sostituzioni come scarto
-                if( $o['punti_attivita'] == 0 ){
-                    mysqlQuery(
-                        $cf['mysql']['connection'],
-                        'INSERT IGNORE INTO sostituzioni_progetti (id_progetto, id_anagrafica, data_scopertura, data_scarto) VALUES (?, ?, ?, ?)',
-                        array(
-                            array( 's' => $id_progetto ),
-                            array( 's' => $o['id_anagrafica'] ),
-                            array( 's' => $dataUltima ),
-                            array( 's' => date( 'Y-m-d') )
-                        )
-                    );
-                }
-                // se il numero di attività che può coprire è maggiore delle richieste già inviate procedo con il calcolo
-                elseif( $o['punti_attivita'] > $richieste_inviate ){
-
-                    // punti copertura: numero attività copribili /numero attività da coprire
-                    $o['punti_copertura'] = intval( $o['punti_attivita'] / count( $attivita ) * 100 );
-                    $o['punteggio'] +=  $o['punti_copertura'];
-                    
-                    // punti distanza
-                    if( $o['punti_attivita'] > 0 && $o['punti_distanza_attivita'] > 0 ){
-                        $o['punti_distanza'] = intval( $o['punti_distanza_attivita'] / $o['punti_attivita'] );
-                        $o['punteggio'] += $o['punti_distanza'];
-                    }         
-
-                    // punti conoscenza del progetto
-                    $o['punti_progetto'] = puntiConoscenzaProgetto( $o['id_anagrafica'], $id_progetto, $dataPrima );
-                    $o['punteggio'] += $o['punti_progetto'];
-               
-                    $op[ $o['id_anagrafica'] ] = $o;
-                }
-                else{
-                    // se può coprire attività ma sono giò state mandate tutte le richieste inserisco una riga nelle sostituzioni_progetti per questo gruppo di attività
-                    mysqlQuery(
-                        $cf['mysql']['connection'],
-                        'INSERT IGNORE INTO sostituzioni_progetti (id_progetto, id_anagrafica, data_scopertura) VALUES (?, ?, ?)',
-                        array(
-                            array( 's' => $id_progetto ),
-                            array( 's' => $o['id_anagrafica'] ),
-                            array( 's' => $dataUltima )
-                        )
-                    );
-                }            
-            }
-
-            // riordino l'array degli operatori in base al punteggio
-            $sort_data = array();
-            foreach( $op as $key => $value ) {
-                $sort_data[ $key ] = $value['punteggio'];
-            }
-
-            if( isset( $sort_data ) ){
-                array_multisort( $sort_data, $op );
-            }
-            
-
-            appendToFile('operatori dopo il calcolo' . print_r( $op, true ) . PHP_EOL, $logdir);
-
-            foreach( $op as $o ){
-                               
-                while( array_key_exists( $o['punteggio'], $candidati ) ){
-                    $o['punteggio']++;
-                }
-
-                $candidati[ $o['punteggio'] ] = $o;
-            }
-            
-            krsort( $candidati );
-        }
-
-        timerCheck( $cf['speed'], 'fine calcolo punteggi');
-
-        return $candidati;
-
-    }
-*/
-
-    // nuova funzione per calcolo sostituti progetto
+    // funzione che calcola l'elenco dei possibili sostituti per un progetto
     function sostitutiProgetto( $id_progetto ){
-
-    #    $logdir = 'var/log/sostitutiProgetto.log';
-
-    #    appendToFile('cerco sostituti progetto ' . $id_progetto . PHP_EOL, $logdir);
 
         global $cf;
 
@@ -890,8 +501,6 @@
                 array( 's' => $id_progetto )
             )
         );
-
-    //    print_r($attivita);
 
         // elenco degli operatori calcolati per le attività scoperte del progetto corrente
         $operatori = mysqlQuery(
@@ -914,8 +523,6 @@
                 array( 's' => $id_progetto  )        
             )
         );
-
-    //    print_r($operatori);
         
         // array di appoggio per il calcolo dei punteggi
         $op = array();
@@ -931,8 +538,6 @@
 
             $op[ $o['id_anagrafica'] ] = $o;
         }
-
-    //    print_r($op);
 
         // riordino l'array degli operatori in base al punteggio
         $sort_data = array();
@@ -953,8 +558,6 @@
         }
     
         krsort( $candidati );
-
-    //    print_r($candidati);
        
         return $candidati;
 

--- a/_mod/_1100.attivita/_src/_inc/_macro/_attivita.form.php
+++ b/_mod/_1100.attivita/_src/_inc/_macro/_attivita.form.php
@@ -200,7 +200,13 @@
         );
     }*/
 
+    // modal per la conferma di sostituzione operatore
+    $ct['page']['contents']['metro'][NULL][] = array(
+        'modal' => array('id' => 'sostituisci-operatore', 'include' => 'inc/attivita.form.modal.sostituisci.operatore.html' )
+    );
+
 	// macro di default
 	require DIR_SRC_INC_MACRO . '_default.form.php';
+    require DIR_SRC_INC_MACRO . '_default.tools.php';
 
  

--- a/_mod/_1100.attivita/_src/_templates/_athena/attivita.form.html
+++ b/_mod/_1100.attivita/_src/_templates/_athena/attivita.form.html
@@ -116,6 +116,9 @@
 						<span class="label-top">esecutore</span>
 						{{ frm.selectBox( table, '', '', 'id_anagrafica', '', etc.select.id_anagrafica_collaboratori, request, session.account.id_anagrafica, '','','','','anagrafica.form','','anagrafica', 'id_anagrafica' , page, pages, ietf,'anagrafica' ) }}
 					</div>
+					<div class="col-auto">
+						<button type="button" style="height: 31px" class="form-control form-control-sm btn btn-sm btn-secondary" onclick="$('#sostituisci-operatore').modal('toggle');">SOSTITUISCI ESECUTORE</button>
+					</div>
 				</div>
 			</fieldset>
 

--- a/_mod/_1100.attivita/_src/_templates/_athena/inc/attivita.form.modal.sostituisci.operatore.html
+++ b/_mod/_1100.attivita/_src/_templates/_athena/inc/attivita.form.modal.sostituisci.operatore.html
@@ -1,0 +1,50 @@
+{% import '_bin/_form.html' as frm %}
+
+{# DEFINIZIONI #}
+{% set table = form.table %}
+{% set ietf = localization.language.ietf %}
+
+<script>
+     function sostituisci() {
+		$('#btnsostituisci').html('<i class="fa fa-circle-o-notch fa-spin fa-fw"></i>');
+		idsostituto = $('#attivita_id_sostituto').val();
+
+		var call = '{{ site.url }}_mod/_1140.variazioni/_src/_api/_task/_sostituzioni.request.php?id_attivita={{ request[table].id }}&id_anagrafica='+idsostituto+'&hard=1';
+
+		getws( call,'', function() {
+		    window.open('{{ page.url[ietf] }}?{{table}}[id]={{ request[table].id }}', '_self');
+		});
+		
+	}
+
+</script>
+
+<div class="modal" tabindex="-1" role="dialog" id="sostituisci-operatore">
+    <div class="modal-dialog" role="document">
+	<div class="modal-content">
+	    <div class="modal-header">
+		    <h5 class="modal-title">sostituisci operatore</h5>
+		    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+	    </div>
+	    <div class="modal-body">
+		<div class="container-fluid">
+		    <div class="form-row">
+                <div class="col">
+                    questa procedura effettuerà la sostituzione diretta dell'operatore assente con quello specificato, tenendo traccia della sostituzione effettuata.
+                </div>
+		    </div>
+            <div class="form-row mt-2">
+                <div class="col">
+                    <span class="label-top">operatore sostituto</span>
+                    {{ frm.selectBox( table, '', '', 'id_sostituto', '', etc.select.id_anagrafica, request ) }}
+                </div>
+            </div>
+	    </div>
+	    </div>
+	    <div class="modal-footer">
+		<button id="btnsostituisci" type="button" class="btn btn-secondary btn-sm" onclick="sostituisci();">conferma</button>
+		<button type="button" class="btn btn-secondary btn-sm" data-dismiss="modal">annulla</button>
+	    </div>
+	</div>
+    </div>
+</div>

--- a/_mod/_1140.variazioni/_src/_api/_job/_sostituzioni.operatore.request.php
+++ b/_mod/_1140.variazioni/_src/_api/_job/_sostituzioni.operatore.request.php
@@ -1,0 +1,176 @@
+<?php
+
+    /**
+     * 
+     * job in foreground creato per sostituire tutte le attività lasciate scoperte da un operatore con un altro
+     * riceve in ingresso i parametri seguenti:
+     * - id_assente: id dell'operatore da sostituire
+     * - id_sostituto: id dell'operatore sostituto
+     * - data_inizio (facoltativa): data di inizio del periodo
+     * - data_fine (facoltativa): data di fine del periodo
+     * 
+     */
+
+    // inizializzo l'array del risultato
+	$status = array();
+
+    // lavoro lungo
+    set_time_limit( 0 );
+
+    // inclusione del framework
+	if( defined( 'CRON_RUNNING' ) || defined( 'JOB_RUNNING' ) ) {
+
+        // verifiche formali (questo per gestire il caso di ciclo a vuoto)
+        if( isset( $job['corrente'] ) && $job['corrente'] >= $job['totale'] ) {
+
+            // status
+            $status['info'][] = 'iterazione a vuoto su job già completato';
+
+        } 
+        elseif( !isset( $job['workspace']['id_assente'] ) || !isset( $job['workspace']['id_sostituto'] ) ){
+            $status['err'][] = 'id_assente o id_sostituto non settati';
+        }
+        else {
+
+            // attività di avvio
+            if( empty( $job['corrente'] ) ) {
+
+                // query da eseguire
+                $q = 'SELECT a.id FROM attivita as a INNER JOIN __report_attivita_assenze__ as r ON a.id = r.id_attivita AND r.id_anagrafica = ? AND a.id_anagrafica IS NULL';
+                
+                // array dei parametri
+                $par = array(
+                    array( 's' => $job['workspace']['id_assente'] )
+                );
+
+                if( ! empty( $job['workspace']['data_inizio'] ) && ! empty( $job['workspace']['data_fine'] ) ){
+                    $status['data_inizio'] = $job['workspace']['data_inizio'];
+                    $status['data_fine'] = $job['workspace']['data_fine'];
+
+                    $q .= ' WHERE a.data_programmazione BETWEEN ? and ?';
+                    $par[] = array( 's' => $job['workspace']['data_inizio'] );
+                    $par[] = array( 's' => $job['workspace']['data_fine'] );
+                }
+
+                $status['query'] = $q;
+                $status['parametri'] = $par;
+
+                // seleziono le attività coinvolte
+                $status['result'] = mysqlSelectColumn(
+                    'id',
+                    $cf['mysql']['connection'],
+                    $q,
+                    $par
+                );
+                
+
+                // creo la lista dei progetti da lavorare
+                $job['workspace']['list'] = $status['result'];
+
+                // segno il totale dei progetti da lavorare
+                $job['totale'] = count( $job['workspace']['list'] );
+
+                // avvio il contatore
+                $job['corrente'] = 1;
+
+                // timestamp di avvio
+                if( empty( $job['timestamp_apertura'] ) ) {
+                    mysqlQuery(
+                        $cf['mysql']['connection'],
+                        'UPDATE job SET timestamp_apertura = ? WHERE id = ?',
+                        array(
+                        array( 's' => time() ),
+                        array( 's' => $job['id'] )
+                        )
+                    );
+                }
+            }
+            else {
+
+                // incremento l'indice di lavoro
+                $job['corrente']++;
+
+            }
+
+            // aggiusto l'indice di lavoro (gli array partono da zero)
+            $widx = $job['corrente'] - 1;
+
+            // ricavo l'ID dell'attività corrente
+            $cid = $job['workspace']['list'][ $widx ];
+            $id_anagrafica =  $job['workspace']['id_sostituto'];
+
+            // logiche di calcolo
+            $copertura = coperturaAttivita( $id_anagrafica, $cid );
+
+            if( $copertura == 1){
+
+                $status['info'][] = 'l\'operatore può coprire l\'attività ' . $cid;
+                
+                // verifico se ci sono già delle richieste di sostituzione
+                $richieste = mysqlSelectValue(
+                    $cf['mysql']['connection'],
+                    'SELECT count(*) FROM sostituzioni_attivita WHERE id_anagrafica = ? AND id_attivita = ?',
+                    array(
+                        array( 's' => $id_anagrafica ),
+                        array( 's' => $cid )
+                    )
+                );
+                
+                // se non c'è già una richiesta la creo
+                if( empty( $richieste ) ){
+                    $url = $cf['site']['url'] . '_mod/_1140.variazioni/_src/_api/_task/_sostituzioni.request.php?id_attivita=' . $cid . '&id_anagrafica=' . $id_anagrafica;
+                    
+                    // se la richiesta arriva in modalità hard aggiungo il parametro per creare le attività
+                    if( !empty( $job['workspace']['hard'] ) ){
+                        $status['hard'] =  $job['workspace']['hard'];
+                        $url .= '&hard=1';
+                    }
+                    $status['attivita'][$cid]['creazione_richiesta'] = restcall(
+                        $url
+                    );
+                }
+            }
+            else{
+                $status['info'][] = 'l\'operatore non può coprire l\'attività ' . $cid;
+            }
+
+            // status
+            $status['info'][] = 'ho lavorato la riga: ' . $cid;
+
+            // aggiorno i valori di visualizzazione avanzamento
+            $jobs = mysqlQuery(
+                $cf['mysql']['connection'],
+                'UPDATE job SET totale = ?, corrente = ? WHERE id = ?',
+                array(
+                array( 's' => $job['totale'] ),
+                array( 's' => $job['corrente'] ),
+                array( 's' => $job['id'] )
+                )
+            );
+
+            // operazioni di chiusura
+            if( $job['corrente'] >= $job['totale'] ) {
+                // scrivo la timestamp di completamento
+                $jobs = mysqlQuery(
+                    $cf['mysql']['connection'],
+                    'UPDATE job SET timestamp_completamento = ? WHERE id = ?',
+                    array(
+                    array( 's' => time() ),
+                    array( 's' => $job['id'] )
+                    )
+                );
+
+            }
+        }
+
+        appendToFile( print_r( $status, true ), 'var/log/sostituzioni_operatore/job_#'.$job['id'] . '.log' );
+
+    } else {
+
+        // status
+		$status['error'][] = 'questo job non può essere lanciato fuori dal cron';
+
+        // output
+        buildJson( $status );
+
+    }

--- a/_mod/_1140.variazioni/_src/_api/_job/_sostituzioni.progetto.request.php
+++ b/_mod/_1140.variazioni/_src/_api/_job/_sostituzioni.progetto.request.php
@@ -2,7 +2,7 @@
 
     /**
      * 
-     *  
+     *  job che 
      * 
      */
 
@@ -30,12 +30,41 @@
             // attività di avvio
             if( empty( $job['corrente'] ) ) {
 
+                // inizializzo gli array delle condizioni where e dei parametri
+                $whr = array();
+                $par = array();
+
+                // progetto
+                $whr[] = 'id_progetto = ?';
+                $par[] = array( 's' => $job['workspace']['id_progetto'] );
+
+
+                if( !empty( $job['workspace']['data_inizio'] ) && !empty( $job['workspace']['data_fine'] ) ){
+                    $whr[] = 'data_programmazione BETWEEN ? AND ?';
+                    $par[] = array( 's' => $job['workspace']['data_inizio'] );
+                    $par[] = array( 's' => $job['workspace']['data_fine'] );
+                }
+
+                if( !empty( $job['workspace']['ora_inizio'] ) && !empty( $job['workspace']['ora_fine'] ) ){
+                    $whr[] = 'ora_inizio_programmazione = ?';
+                    $whr[] = 'ora_fine_programmazione = ?';
+                    $par[] = array( 's' => $job['workspace']['ora_inizio'] );
+                    $par[] = array( 's' => $job['workspace']['ora_fine'] );
+                }
+
+                $q = 'SELECT id FROM attivita WHERE id_anagrafica IS NULL AND ('  . implode( ' AND ', $whr ) . ')';
+
+                $status['query'] = $q;
+                $status['parametri'] = $par;
+
+                // seleziono le attività coinvolte
                 $status['result'] = mysqlSelectColumn(
-				    'id',
+                    'id',
                     $cf['mysql']['connection'],
-                    'SELECT id FROM attivita WHERE id_progetto = ? AND id_anagrafica IS NULL',
-                    array( array( 's' => $job['workspace']['id_progetto'] ) )
+                    $q,
+                    $par
                 );
+                
 
                 // creo la lista dei progetti da lavorare
                 $job['workspace']['list'] = $status['result'];
@@ -130,6 +159,7 @@
 
             }
         }
+
     } else {
 
         // status

--- a/_mod/_1140.variazioni/_src/_inc/_macro/_progetti.scoperti.form.php
+++ b/_mod/_1140.variazioni/_src/_inc/_macro/_progetti.scoperti.form.php
@@ -43,7 +43,9 @@
 
             $nome =  ( !isset( $_REQUEST['__sostituzione__']['hard'] ) ) ? 'richiesta ' : '';
             $nome .= 'sostituzione progetto ' . $_REQUEST[ $ct['form']['table'] ]['id'] . ' con anagrafica ' . $_REQUEST['__sostituzione__']['id_anagrafica'] . ' - ' . $anagrafica;
-            
+            $nome .=  ( isset( $_REQUEST['__sostituzione__']['data_inizio'] ) && isset( $_REQUEST['__sostituzione__']['data_fine'] ) ) ? ' dal ' . $_REQUEST['__sostituzione__']['data_inizio'] . ' al ' . $_REQUEST['__sostituzione__']['data_fine'] : '';
+            $nome .=  ( isset( $_REQUEST['__sostituzione__']['ora_inizio'] ) && isset( $_REQUEST['__sostituzione__']['ora_fine'] ) ) ? ' orario ' . $_REQUEST['__sostituzione__']['ora_inizio'] . '-' . $_REQUEST['__sostituzione__']['ora_fine'] : '';
+
             $job = mysqlQuery(
                 $cf['mysql']['connection'],
                 'INSERT INTO job ( nome, job, iterazioni, workspace, se_foreground, delay ) VALUES ( ?, ?, ?, ?, ?, ? )',
@@ -55,6 +57,10 @@
                         array(
                             'id_progetto' => $_REQUEST[ $ct['form']['table'] ]['id'],
                             'id_anagrafica' => $_REQUEST['__sostituzione__']['id_anagrafica'],
+                            'data_inizio' => isset( $_REQUEST['__sostituzione__']['data_inizio'] ) ? $_REQUEST['__sostituzione__']['data_inizio'] : NULL,
+                            'data_fine' => isset( $_REQUEST['__sostituzione__']['data_fine'] ) ? $_REQUEST['__sostituzione__']['data_fine'] : NULL,
+                            'ora_inizio' => isset( $_REQUEST['__sostituzione__']['ora_inizio'] ) ? $_REQUEST['__sostituzione__']['ora_inizio'] : NULL,
+                            'ora_fine' => isset( $_REQUEST['__sostituzione__']['ora_fine'] ) ? $_REQUEST['__sostituzione__']['ora_fine'] : NULL,
                             'hard' => ( isset( $_REQUEST['__sostituzione__']['hard'] ) ) ? $_REQUEST['__sostituzione__']['hard'] : NULL
                         )
                     ) ),
@@ -62,6 +68,7 @@
                     array( 's' => 3 )
                 )
             );
+            
         }
 
 

--- a/_mod/_1140.variazioni/_src/_inc/_macro/_variazioni.tools.php
+++ b/_mod/_1140.variazioni/_src/_inc/_macro/_variazioni.tools.php
@@ -12,7 +12,10 @@
      // gruppi di controlli
 	$ct['page']['contents']['metros'] = array(
 	    'azioni' => array(
-		'label' => 'azioni'
+			'label' => 'azioni'
+		),
+		'sostituzioni' => array(
+			'label' => 'sostituzioni'
 	    )
 	);
 
@@ -40,6 +43,65 @@
 	    'title' => 'libera operatore',
 	    'text' => 'rimuove un operatore dalle attività di un progetto'
 	);
+
+	// richiesta sostituzione per operatore
+	$ct['page']['contents']['metro']['sostituzioni'][] = array(
+        'modal' => array('id' => 'richiesta', 'include' => 'inc/variazioni.tools.modal.operatore.richiesta.html' ),
+	    'icon' => NULL,
+	    'fa' => 'fa-files-o',
+	    'title' => 'richiedi sostituzione operatore',
+	    'text' => 'invia la richiesta di sostituzione di un operatore con un altro'
+	);
+	
+	// sostituzione per operatore
+	$ct['page']['contents']['metro']['sostituzioni'][] = array(
+        'modal' => array('id' => 'sostituisci', 'include' => 'inc/variazioni.tools.modal.operatore.sostituisci.html' ),
+	    'icon' => NULL,
+	    'fa' => 'fa-files-o',
+	    'title' => 'sostituisci operatore',
+	    'text' => 'effettua la sostituzione di un operatore con un altro'
+	);
+
+	// se ho una richiesta di sostituzione creo il job relativo
+	if( !empty( $_REQUEST['__sostituzione__']['id_assente'] ) && !empty( $_REQUEST['__sostituzione__']['id_sostituto'] ) ){
+
+		$assente = mysqlSelectValue(
+			$cf['mysql']['connection'],
+			'SELECT __label__ FROM anagrafica_view_static WHERE id = ?',
+			array( array( 's' => $_REQUEST['__sostituzione__']['id_assente'] ) )
+		);
+
+		$sostituto = mysqlSelectValue(
+			$cf['mysql']['connection'],
+			'SELECT __label__ FROM anagrafica_view_static WHERE id = ?',
+			array( array( 's' => $_REQUEST['__sostituzione__']['id_sostituto'] ) )
+		);
+
+		$nome =  ( !isset( $_REQUEST['__sostituzione__']['hard'] ) ) ? 'richiesta ' : '';
+		$nome .= 'sostituzione operatore ' . $assente . ' con ' . $sostituto;
+		$nome .=  ( isset( $_REQUEST['__sostituzione__']['data_inizio'] ) && isset( $_REQUEST['__sostituzione__']['data_fine'] ) ) ? ' dal ' . $_REQUEST['__sostituzione__']['data_inizio'] . ' al ' . $_REQUEST['__sostituzione__']['data_fine'] : '';
+
+		$job = mysqlQuery(
+			$cf['mysql']['connection'],
+			'INSERT INTO job ( nome, job, iterazioni, workspace, se_foreground, delay ) VALUES ( ?, ?, ?, ?, ?, ? )',
+			array(
+				array( 's' => $nome ),
+				array( 's' => '_mod/_1140.variazioni/_src/_api/_job/_sostituzioni.operatore.request.php' ),
+				array( 's' => 10 ),
+				array( 's' => json_encode(
+					array(
+						'id_assente' => $_REQUEST['__sostituzione__']['id_assente'],
+						'id_sostituto' => $_REQUEST['__sostituzione__']['id_sostituto'],
+						'data_inizio' => isset( $_REQUEST['__sostituzione__']['data_inizio'] ) ? $_REQUEST['__sostituzione__']['data_inizio'] : NULL,
+						'data_fine' => isset( $_REQUEST['__sostituzione__']['data_fine'] ) ? $_REQUEST['__sostituzione__']['data_fine'] : NULL,
+						'hard' => ( isset( $_REQUEST['__sostituzione__']['hard'] ) ) ? $_REQUEST['__sostituzione__']['hard'] : NULL
+					)
+				) ),
+				array( 's' => 1 ),
+				array( 's' => 3 )
+			)
+		);	
+	}
 
 
 	// macro di default

--- a/_mod/_1140.variazioni/_src/_templates/_athena/inc/progetti.scoperti.form.modal.richiesta.html
+++ b/_mod/_1140.variazioni/_src/_templates/_athena/inc/progetti.scoperti.form.modal.richiesta.html
@@ -49,21 +49,21 @@
 				</div>
 			</div>
 			<div class="form-row  mt-2">
-				<div class="col-12 col-md-auto">
+				<div class="col-6">
 					<span class="label-top">data inizio</span>
 					{{ frm.date( '', '', '', 'data_inizio_richiesta', '', '', request, default, '', 1 ) }}
 				</div>
 
-				<div class="col-12 col-md-auto">
+				<div class="col-6">
 					<span class="label-top">data fine</span>
 					{{ frm.date( '', '', '', 'data_fine_richiesta', '', '', request, default, '', 1 ) }}
 				</div>
 
-				<div class="col-6 col-md-">
+				<div class="col-6">
 					<span class="label-top">ora inizio</span>
 					{{ frm.time( '', '', '', 'ora_inizio_richiesta', '', '', request) }} 
 				</div>
-				<div class="col-6 col-md">
+				<div class="col-6">
 					<span class="label-top">ora fine</span>
 					{{ frm.time( '', '', '', 'ora_fine_richiesta', '', '', request) }} 
 				</div>

--- a/_mod/_1140.variazioni/_src/_templates/_athena/inc/progetti.scoperti.form.modal.richiesta.html
+++ b/_mod/_1140.variazioni/_src/_templates/_athena/inc/progetti.scoperti.form.modal.richiesta.html
@@ -5,18 +5,27 @@
 {% set ietf = localization.language.ietf %}
 
 <script>
-     function inviaRichiesta() {
+     function inviaRichiesta( t ) {
 		$('#btnrichiedi').html('<i class="fa fa-circle-o-notch fa-spin fa-fw"></i>');
-		idoperatore = $('#modaloperatoreid').text();
+		var form = $( t ).closest('.modal');
+		var idoperatore = $('#modaloperatoreid').text();
+		var data_inizio = form.find('#_data_inizio_richiesta').val();
+		var data_fine = form.find('#_data_fine_richiesta').val();
+		var ora_inizio = form.find('#_ora_inizio_richiesta').val();
+		var ora_fine = form.find('#_ora_fine_richiesta').val();
 
-		window.open('{{ page.url[ietf] }}?{{table}}[id]={{ request[table].id }}&__sostituzione__[id_anagrafica]='+idoperatore, '_self');
+		var call = '{{ page.url[ietf] }}?{{table}}[id]={{ request[table].id }}&__sostituzione__[id_anagrafica]='+idoperatore;
 
-	/*	var call = '{{ site.url }}_mod/_1140.variazioni/_src/_api/_task/_sostituzioni.progetto.request.php?id_progetto={{ request[table].id }}&id_anagrafica='+idoperatore+'&data_scopertura={{ etc.data_scopertura }}';
+		if( data_inizio && data_fine ){
+			call += '&__sostituzione__[data_inizio]='+data_inizio+'&__sostituzione__[data_fine]='+data_fine;
+		}
 
-		getws( call,'', function() {
-			window.open('{{ page.url[ietf] }}?{{table}}[id]={{ request[table].id }}', '_self');
-		});
-	*/	
+		if( ora_inizio && ora_fine ){
+			call += '&__sostituzione__[ora_inizio]='+ora_inizio+'&__sostituzione__[ora_fine]='+ora_fine;
+		}
+
+		window.open( call, '_self');
+
 	}
 
 </script>
@@ -31,15 +40,38 @@
 	    <div class="modal-body">
 		<div class="container-fluid">
 		    <div class="form-row">
-			<div class="col">
-				si desidera inviare una richiesta di sostituzione per le attività del progetto {{ request[table].id }} all'operatore 
-                <span id="modaloperatoreid"></span> - <span id="modaloperatorenome"></span> ?
+				<div class="col">
+					questa operazione invierà una richiesta di sostituzione per le attività del progetto {{ request[table].id }} all'operatore 
+					<span id="modaloperatoreid"></span> - <span id="modaloperatorenome"></span>
+				</div>
+				<div class="col-12">
+					per limitare la richiesta ad un periodo e/o ad una determinata fascia oraria specificare gli intervalli di date e orari. se non specificati, la richiesta verrà inviata per tutte le attività scoperte del progetto.
+				</div>
 			</div>
-		</div>
+			<div class="form-row  mt-2">
+				<div class="col-12 col-md-auto">
+					<span class="label-top">data inizio</span>
+					{{ frm.date( '', '', '', 'data_inizio_richiesta', '', '', request, default, '', 1 ) }}
+				</div>
+
+				<div class="col-12 col-md-auto">
+					<span class="label-top">data fine</span>
+					{{ frm.date( '', '', '', 'data_fine_richiesta', '', '', request, default, '', 1 ) }}
+				</div>
+
+				<div class="col-6 col-md-">
+					<span class="label-top">ora inizio</span>
+					{{ frm.time( '', '', '', 'ora_inizio_richiesta', '', '', request) }} 
+				</div>
+				<div class="col-6 col-md">
+					<span class="label-top">ora fine</span>
+					{{ frm.time( '', '', '', 'ora_fine_richiesta', '', '', request) }} 
+				</div>
+			</div>
 	    </div>
 	    </div>
 	    <div class="modal-footer">
-		<button id="btnrichiedi" type="button" class="btn btn-secondary btn-sm" onclick="inviaRichiesta();">conferma</button>
+		<button id="btnrichiedi" type="button" class="btn btn-secondary btn-sm" onclick="inviaRichiesta( this );">conferma</button>
 		<button type="button" class="btn btn-secondary btn-sm" data-dismiss="modal">annulla</button>
 	    </div>
 	</div>

--- a/_mod/_1140.variazioni/_src/_templates/_athena/inc/progetti.scoperti.form.modal.sostituisci.html
+++ b/_mod/_1140.variazioni/_src/_templates/_athena/inc/progetti.scoperti.form.modal.sostituisci.html
@@ -50,22 +50,22 @@
 						</div>
 					</div>
 
-					<div class="form-row  mt-2">
-						<div class="col-12 col-md">
+					<div class="form-row mt-2">
+						<div class="col-6">
 							<span class="label-top">data inizio</span>
 							{{ frm.date( '', '', '', 'data_inizio_sostituzione', '', '', request, default, '', 1 ) }}
 						</div>
 
-						<div class="col-12 col-md">
+						<div class="col-6">
 							<span class="label-top">data fine</span>
 							{{ frm.date( '', '', '', 'data_fine_sostituzione', '', '', request, default, '', 1 ) }}
 						</div>
 
-						<div class="col-6 col-md-">
+						<div class="col-6">
 							<span class="label-top">ora inizio</span>
 							{{ frm.time( '', '', '', 'ora_inizio_sostituzione', '', '', request) }} 
 						</div>
-						<div class="col-6 col-md">
+						<div class="col-6">
 							<span class="label-top">ora fine</span>
 							{{ frm.time( '', '', '', 'ora_fine_sostituzione', '', '', request) }} 
 						</div>

--- a/_mod/_1140.variazioni/_src/_templates/_athena/inc/progetti.scoperti.form.modal.sostituisci.html
+++ b/_mod/_1140.variazioni/_src/_templates/_athena/inc/progetti.scoperti.form.modal.sostituisci.html
@@ -5,43 +5,77 @@
 {% set ietf = localization.language.ietf %}
 
 <script>
-     function sostituisci() {
+     function sostituisci(t) {
 		$('#btnsostituisci').html('<i class="fa fa-circle-o-notch fa-spin fa-fw"></i>');
-		idoperatore = $('#modaloperatoreSid').text();
+		var form = $( t ).closest('.modal');
+		var idoperatore = $('#modaloperatoreSid').text();
+		var data_inizio = form.find('#_data_inizio_sostituzione').val();
+		var data_fine = form.find('#_data_fine_sostituzione').val();
+		var ora_inizio = form.find('#_ora_inizio_sostituzione').val();
+		var ora_fine = form.find('#_ora_fine_sostituzione').val();
 
-		window.open('{{ page.url[ietf] }}?{{table}}[id]={{ request[table].id }}&__sostituzione__[id_anagrafica]='+idoperatore+'&__sostituzione__[hard]=1', '_self');
-	/*	var call = '{{ site.url }}_mod/_1140.variazioni/_src/_api/_task/_sostituzioni.progetto.request.php?id_progetto={{ request[table].id }}&id_anagrafica='+idoperatore+'&hard=1';
+		var call = '{{ page.url[ietf] }}?{{table}}[id]={{ request[table].id }}&__sostituzione__[id_anagrafica]='+idoperatore+'&__sostituzione__[hard]=1';
 
-		getws( call,'', function() {
-			window.open('{{ pages['progetti.scoperti.view'].path[ localization.language.ietf ] }}','_self');
-		});
-	*/	
+		if( data_inizio && data_fine ){
+			call += '&__sostituzione__[data_inizio]='+data_inizio+'&__sostituzione__[data_fine]='+data_fine;
+		}
+
+		if( ora_inizio && ora_fine ){
+			call += '&__sostituzione__[ora_inizio]='+ora_inizio+'&__sostituzione__[ora_fine]='+ora_fine;
+		}
+
+		window.open( call, '_self');
+
 	}
 
 </script>
 
 <div class="modal" tabindex="-1" role="dialog" id="sostituisci">
     <div class="modal-dialog" role="document">
-	<div class="modal-content">
-	    <div class="modal-header">
-		<h5 class="modal-title">effettua sostituzione</h5>
-		<button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-	    </div>
-	    <div class="modal-body">
-		<div class="container-fluid">
-		    <div class="form-row">
-			<div class="col">
-				si desidera effettuare direttamente la sostituzione assegnando 
-				all'operatore <span id="modaloperatoreSid"></span> - <span id="modaloperatoreSnome"></span>
-				le attività del progetto {{ request[table].id }} che può coprire senza inviare una richiesta?
+		<div class="modal-content">
+			<div class="modal-header">
+				<h5 class="modal-title">effettua sostituzione</h5>
+				<button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+			</div>
+			<div class="modal-body">
+				<div class="container-fluid">
+					<div class="form-row">
+						<div class="col">
+							questa operazione effetuerà direttamente la sostituzione assegnando 
+							all'operatore <span id="modaloperatoreSid"></span> - <span id="modaloperatoreSnome"></span>
+							le attività del progetto {{ request[table].id }} che può coprire senza inviare una richiesta.
+						</div>
+						<div class="col-12">
+							per limitare la sostituzione ad un periodo e/o ad una determinata fascia oraria specificare gli intervalli di date e orari. se non specificati, la sostituzione verrà effettuata per tutte le attività scoperte del progetto.
+						</div>
+					</div>
+
+					<div class="form-row  mt-2">
+						<div class="col-12 col-md">
+							<span class="label-top">data inizio</span>
+							{{ frm.date( '', '', '', 'data_inizio_sostituzione', '', '', request, default, '', 1 ) }}
+						</div>
+
+						<div class="col-12 col-md">
+							<span class="label-top">data fine</span>
+							{{ frm.date( '', '', '', 'data_fine_sostituzione', '', '', request, default, '', 1 ) }}
+						</div>
+
+						<div class="col-6 col-md-">
+							<span class="label-top">ora inizio</span>
+							{{ frm.time( '', '', '', 'ora_inizio_sostituzione', '', '', request) }} 
+						</div>
+						<div class="col-6 col-md">
+							<span class="label-top">ora fine</span>
+							{{ frm.time( '', '', '', 'ora_fine_sostituzione', '', '', request) }} 
+						</div>
+					</div>
+				</div>
+			</div>
+			<div class="modal-footer">
+				<button id="btnsostituisci" type="button" class="btn btn-secondary btn-sm" onclick="sostituisci( this );">conferma</button>
+				<button type="button" class="btn btn-secondary btn-sm" data-dismiss="modal">annulla</button>
 			</div>
 		</div>
-	    </div>
-	    </div>
-	    <div class="modal-footer">
-		<button id="btnsostituisci" type="button" class="btn btn-secondary btn-sm" onclick="sostituisci();">conferma</button>
-		<button type="button" class="btn btn-secondary btn-sm" data-dismiss="modal">annulla</button>
-	    </div>
-	</div>
     </div>
 </div>

--- a/_mod/_1140.variazioni/_src/_templates/_athena/inc/variazioni.tools.modal.operatore.richiesta.html
+++ b/_mod/_1140.variazioni/_src/_templates/_athena/inc/variazioni.tools.modal.operatore.richiesta.html
@@ -1,0 +1,73 @@
+{% import '_bin/_form.html' as frm %}
+
+{# DEFINIZIONI #}
+{% set ietf = localization.language.ietf %}
+
+<script>
+    function inviaRichiesta( t ) {
+        $('#btnrichiedi').html('<i class="fa fa-circle-o-notch fa-spin fa-fw"></i>');
+        var form = $( t ).closest('.modal');		
+        var assente = form.find('#_id_assente_r').val();
+        var sostituto = form.find('#_id_sostituto_r').val();
+        var data_inizio = form.find('#_data_inizio_r').val();
+        var data_fine = form.find('#_data_fine_r').val();
+
+	 	var call = '{{ page.url[ietf] }}?__sostituzione__[id_assente]='+assente+'&__sostituzione__[id_sostituto]='+sostituto;
+        
+        if( data_inizio && data_fine ){
+            call += '&__sostituzione__[data_inizio]='+data_inizio+'&__sostituzione__[data_fine]='+data_fine;
+        }
+
+        window.open( call, '_self');
+       
+	}
+</script>
+
+<div class="modal" tabindex="-1" role="dialog" id="richiesta">
+    <div class="modal-dialog" role="document">
+	<div class="modal-content">
+	    <div class="modal-header">
+            <h5 class="modal-title">invia richiesta</h5>
+            <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+	    </div>
+	    <div class="modal-body">
+            <div class="container-fluid">
+                <div class="form-row">
+                    <div class="col">
+                        questa operazione invierà una richiesta di sostituzione per le attività scoperte di un operatore assente ad altro operatore
+                    </div>
+                    <div class="col-12">
+                        per limitare la richiesta ad un periodo indicare la data di inizio e fine. se non specificate, la richiesta verrà inviata per tutte le attività scoperte dell'operatore.
+                    </div>
+                </div>
+                <div class="form-row mt-2">
+                    <div class="col">
+                        <span class="label-top">operatore assente</span>
+                        {{ frm.selectBox( table, '', '', 'id_assente_r', '', etc.select.anagrafica, request ) }}
+                    </div>
+                </div>
+                <div class="form-row">
+                    <div class="col">
+                        <span class="label-top">operatore sostituto</span>
+                        {{ frm.selectBox( table, '', '', 'id_sostituto_r', '', etc.select.anagrafica, request ) }}
+                    </div>
+                </div>
+                <div class="form-row">
+                    <div class="col">
+                        <span class="label-top">data inizio</span>
+                        {{ frm.date( table, '', '', 'data_inizio_r', '', '', request, default ) }}
+                    </div>
+                    <div class="col">
+                        <span class="label-top">data fine</span>
+                        {{ frm.date( table, '', '', 'data_fine_r', '', '', request, default ) }}
+                    </div>
+                </div>
+            </div>
+	    </div>
+	    <div class="modal-footer">
+            <button type="button" id="btnrichiedi" class="btn btn-secondary btn-sm" onclick="inviaRichiesta(this);">conferma</button>
+            <button type="button" class="btn btn-secondary btn-sm" data-dismiss="modal">annulla</button>
+	    </div>
+	</div>
+    </div>
+</div>

--- a/_mod/_1140.variazioni/_src/_templates/_athena/inc/variazioni.tools.modal.operatore.sostituisci.html
+++ b/_mod/_1140.variazioni/_src/_templates/_athena/inc/variazioni.tools.modal.operatore.sostituisci.html
@@ -1,0 +1,70 @@
+{% import '_bin/_form.html' as frm %}
+
+{# DEFINIZIONI #}
+{% set ietf = localization.language.ietf %}
+
+<script>
+    function sostituisci( t ) {
+        $('#btnsostituisci').html('<i class="fa fa-circle-o-notch fa-spin fa-fw"></i>');
+        var form = $( t ).closest('.modal');		
+        var assente = form.find('#_id_assente_s').val();
+        var sostituto = form.find('#_id_sostituto_s').val();
+        var data_inizio = form.find('#_data_inizio_s').val();
+        var data_fine = form.find('#_data_fine_s').val();
+
+        var call = '{{ page.url[ietf] }}?__sostituzione__[id_assente]='+assente+'&__sostituzione__[id_sostituto]='+sostituto+'&__sostituzione__[hard]=1';
+               
+        if( data_inizio && data_fine ){
+            call += '&__sostituzione__[data_inizio]='+data_inizio+'&__sostituzione__[data_fine]='+data_fine;
+        }
+
+        window.open( call, '_self');
+	}
+</script>
+
+<div class="modal" tabindex="-1" role="dialog" id="sostituisci">
+    <div class="modal-dialog" role="document">
+	<div class="modal-content">
+	    <div class="modal-header">
+            <h5 class="modal-title">sostituisci operatore</h5>
+            <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+	    </div>
+	    <div class="modal-body">
+            <div class="container-fluid">
+                <div class="form-row">
+                    <div class="col">
+                        questa procedura permette di sostituire un operatore con un altro per tutte le attività scoperte.<br>
+                        se si desidera limitare la sostituzione ad un determinato periodo, specificare la data di inizio e fine.
+                    </div>
+                </div>
+                <div class="form-row mt-2">
+                    <div class="col">
+                        <span class="label-top">operatore assente</span>
+                        {{ frm.selectBox( table, '', '', 'id_assente_s', '', etc.select.anagrafica, request ) }}
+                    </div>
+                </div>
+                <div class="form-row">
+                    <div class="col">
+                        <span class="label-top">operatore sostituto</span>
+                        {{ frm.selectBox( table, '', '', 'id_sostituto_s', '', etc.select.anagrafica, request ) }}
+                    </div>
+                </div>
+                <div class="form-row">
+                    <div class="col">
+                        <span class="label-top">data inizio</span>
+                        {{ frm.date( table, '', '', 'data_inizio_s', '', '', request, default ) }}
+                    </div>
+                    <div class="col">
+                        <span class="label-top">data fine</span>
+                        {{ frm.date( table, '', '', 'data_fine_s', '', '', request, default ) }}
+                    </div>
+                </div>
+            </div>
+	    </div>
+	    <div class="modal-footer">
+            <button type="button" id="btnsostituisci" class="btn btn-secondary btn-sm" onclick="sostituisci(this);">conferma</button>
+            <button type="button" class="btn btn-secondary btn-sm" data-dismiss="modal">annulla</button>
+	    </div>
+	</div>
+    </div>
+</div>


### PR DESCRIPTION
- nella form attività inserito tasto per effettuare la sostituzione manuale di un operatore tenendo traccia della sostituzione
- modificato sostituzione per progetto in modo da prevedere la possibilità di applicare la sostituzione ad un determinato periodo e ad una certa fascia oraria
- inserito possibilità di effettuare sostituzioni per operatore (inserito i due tasti per richiesta e sostituzione diretta su form variazioni.tools)
- rimosso codice obsoleto da libreria mysql.utils.php su modulo produzione