### PR TITLE
Feature/migliorie disponibilita dipendenti

### DIFF
--- a/_mod/_1000.produzione/_src/_lib/_mysql.utils.php
+++ b/_mod/_1000.produzione/_src/_lib/_mysql.utils.php
@@ -175,7 +175,7 @@
             'SELECT count(*) FROM orari_contratti '
             .'WHERE orari_contratti.se_disponibile = 1 '
             .'AND orari_contratti.id_contratto = ? '
-            .'AND orari_contratti.id_giorno = ? '
+            .'AND ( orari_contratti.id_giorno = ? OR orari_contratti.id_giorno IS NULL ) '
             .'AND orari_contratti.ora_inizio <= ? AND orari_contratti.ora_fine >= ? ',
             array(
                 array( 's' => $cId ),

--- a/_mod/_1000.produzione/_src/_lib/_mysql.utils.php
+++ b/_mod/_1000.produzione/_src/_lib/_mysql.utils.php
@@ -188,7 +188,7 @@
         $result['disponibile'] = $disponibile;
 
         if( $disponibile > 0 ){
-            $punti = 50;
+            $punti = 100;
         }
 
         //return $result;

--- a/_mod/_6600.contratti/_src/_templates/_athena/bin/contratti.form.disponibilita.sub.html
+++ b/_mod/_6600.contratti/_src/_templates/_athena/bin/contratti.form.disponibilita.sub.html
@@ -20,7 +20,7 @@
 	<div class="form-group form-row">
 	    <div class="col-md-2">
 		    <span class="label-top">giorno</span>
-		    {{ frm.selectRequired( table, subtable, i, 'id_giorno', '', etc.select.giorno, request, '', '', '', disabled  ) }}
+            {{ frm.select( table, subtable, i, 'id_giorno', '', etc.select.giorno, request, '', '', '', '', '', disabled ) }}
         </div>
         <div class="col-md-2">
             <span class="label-top">ora inizio</span>


### PR DESCRIPTION
- nella tabella _orari_contratti_ settato _id_giorno_ non obbligatorio: lato front-end, nella maschera di orari contratti rimane required, mentre in quella delle disponibilità può essere NULL, in tal caso significa che la persona è disponibile tutti i giorni nella fascia oraria specificata
- nella libreria di calcolo sostituti modificato la funzione che calcola la disponibilità per gestire il caso di cui sopra, più settato i punti disponibilità da 50 a 100 se la persona è disponibile.